### PR TITLE
Add club and golf course management pages

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,43 @@
+---
+description: Stage changes if needed, push a branch, and open a PR if needed
+---
+
+# Commit Workflow
+
+Execute these steps in order. Fix any issues before proceeding to the next step.
+
+## Step 1: Branch Check
+
+Check current branch with `git branch --show-current`. If on `main`:
+
+1. Ask user for a branch name
+2. Create and checkout the new branch: `git checkout -b <branch-name>`
+
+## Step 2: Stage Changes
+
+Run `git add -A` to stage all changes.
+
+## Step 3: Commit
+
+1. Run `git diff --cached --stat` to summarize staged changes
+2. Create a concise commit message describing the changes
+3. Commit using:
+
+```bash
+git commit -m "$(cat <<'EOF'
+<commit message>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Step 4: Push
+
+Push branch to remote: `git push -u origin <branch-name>`
+
+## Step 9: PR
+
+If there is not already an open PR create one using `gh pr create` with a summary of changes

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -38,6 +38,6 @@ EOF
 
 Push branch to remote: `git push -u origin <branch-name>`
 
-## Step 9: PR
+## Step 5: PR
 
 If there is not already an open PR create one using `gh pr create` with a summary of changes

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: review-pr
 description: Read and respond to GitHub PR code review comments on the current branch's PR.
-user-invocable: true
-disable-model-invocation: true
 ---
 
 # Review PR Comments
@@ -59,6 +57,8 @@ For each thread:
 - The original comment (abbreviated if long)
 - Any code changes made (as a diff or description)
 - The drafted reply text
+
+IMPORTANT: Summarize in table form as well.
 
 Ask the user to approve, edit, or skip each response.
 

--- a/apps/admin/src/app/(dashboard)/admin/users/page.tsx
+++ b/apps/admin/src/app/(dashboard)/admin/users/page.tsx
@@ -160,7 +160,7 @@ export default function UsersPage() {
 									<TableHead>Role</TableHead>
 									<TableHead>Status</TableHead>
 									<TableHead>Created</TableHead>
-									<TableHead className="w-[70px]"></TableHead>
+									<TableHead className="w-18"></TableHead>
 								</TableRow>
 							</TableHeader>
 							<TableBody>

--- a/apps/admin/src/app/(dashboard)/match-play/landing/actions.ts
+++ b/apps/admin/src/app/(dashboard)/match-play/landing/actions.ts
@@ -8,8 +8,8 @@ import {
 	saveContentAction as saveContent,
 } from "@/lib/content-actions"
 
-export async function getContentAction(contentType: string): Promise<ActionResult<ContentData>> {
-	return getContent(contentType)
+export async function getContentAction(): Promise<ActionResult<ContentData>> {
+	return getContent("M")
 }
 
 export async function saveContentAction(data: {
@@ -18,5 +18,5 @@ export async function saveContentAction(data: {
 	title: string
 	contentText: string
 }): Promise<ActionResult<{ id: number }>> {
-	return saveContent(data, "/tournaments")
+	return saveContent(data, "/match-play")
 }

--- a/apps/admin/src/app/(dashboard)/match-play/landing/page.tsx
+++ b/apps/admin/src/app/(dashboard)/match-play/landing/page.tsx
@@ -1,14 +1,44 @@
 import { H1 } from "@mpga/ui"
 
+import { ContentEditor } from "@/components/content-editor"
+
+import { getContentAction, saveContentAction } from "./actions"
+
+async function loadLandingContent() {
+	"use server"
+	const result = await getContentAction()
+	if (!result.success || !result.data) return null
+	return {
+		title: result.data.title,
+		content: result.data.contentText,
+		id: result.data.id,
+	}
+}
+
+async function saveLandingContent(data: { id?: number; title: string; content: string }) {
+	"use server"
+	return saveContentAction({
+		id: data.id,
+		contentType: "M",
+		title: data.title,
+		contentText: data.content,
+	})
+}
+
 export default function MatchPlayLandingPagePage() {
 	return (
 		<div className="mx-auto max-w-6xl">
-			<H1 variant="secondary" className="mb-6">
+			<H1 variant="secondary" className="mb-2">
 				Match Play Landing Page
 			</H1>
-			<div className="rounded-lg border bg-white p-6">
-				<p className="text-gray-500">Match Play Landing Page management coming soon.</p>
-			</div>
+			<p className="mb-6 text-muted-foreground">
+				This content is displayed at the top of the Match Play page on the public site.
+			</p>
+			<ContentEditor
+				loadContent={loadLandingContent}
+				saveContent={saveLandingContent}
+				preview={{ heading: "h1" }}
+			/>
 		</div>
 	)
 }

--- a/apps/admin/src/app/(dashboard)/members/clubs/[id]/club-contacts-section.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/[id]/club-contacts-section.tsx
@@ -1,0 +1,278 @@
+"use client"
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+	Badge,
+	Button,
+	Card,
+	CardContent,
+	CardHeader,
+	CardTitle,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+	toast,
+} from "@mpga/ui"
+import { Star, Trash2, X } from "lucide-react"
+import { useEffect, useState } from "react"
+
+import {
+	type ClubContactData,
+	addClubContactRoleAction,
+	removeClubContactAction,
+	removeClubContactRoleAction,
+	toggleClubContactPrimaryAction,
+} from "../actions"
+import { ContactSearchDialog } from "./contact-search-dialog"
+
+const PREDEFINED_ROLES = [
+	"Clubhouse Manager",
+	"Director of Golf",
+	"Event Director",
+	"General Manager",
+	"Handicap Chair",
+	"Manager",
+	"Match Play Captain",
+	"Men's Club Contact",
+	"Men's Club President",
+	"Men's Club Secretary",
+	"Men's Club Tournament Chair",
+	"Men's Club Treasurer",
+	"Men's Club VP",
+	"Owner",
+	"PGA Professional",
+	"Pro Shop Manager",
+	"Sr. Match Play Captain",
+	"Superintendent",
+]
+
+interface ClubContactsSectionProps {
+	clubId: number
+	contacts: ClubContactData[]
+	onRefresh: () => Promise<void>
+}
+
+export function ClubContactsSection({ clubId, contacts, onRefresh }: ClubContactsSectionProps) {
+	const [mounted, setMounted] = useState(false)
+	const [removing, setRemoving] = useState<number | null>(null)
+
+	useEffect(() => setMounted(true), [])
+
+	const handleRemoveContact = async (clubContactId: number) => {
+		setRemoving(clubContactId)
+		try {
+			const result = await removeClubContactAction(clubContactId)
+			if (result.success) {
+				toast.success("Contact removed")
+				await onRefresh()
+			} else {
+				toast.error(result.error ?? "Failed to remove contact")
+			}
+		} catch (err) {
+			console.error("Failed to remove contact:", err)
+			toast.error("Failed to remove contact")
+		} finally {
+			setRemoving(null)
+		}
+	}
+
+	const handleAddRole = async (clubContactId: number, role: string) => {
+		try {
+			const result = await addClubContactRoleAction(clubContactId, role)
+			if (result.success) {
+				await onRefresh()
+			} else {
+				toast.error(result.error ?? "Failed to add role")
+			}
+		} catch (err) {
+			console.error("Failed to add role:", err)
+			toast.error("Failed to add role")
+		}
+	}
+
+	const handleRemoveRole = async (roleId: number) => {
+		try {
+			const result = await removeClubContactRoleAction(roleId)
+			if (result.success) {
+				await onRefresh()
+			} else {
+				toast.error(result.error ?? "Failed to remove role")
+			}
+		} catch (err) {
+			console.error("Failed to remove role:", err)
+			toast.error("Failed to remove role")
+		}
+	}
+
+	const handleTogglePrimary = async (clubContactId: number) => {
+		try {
+			const result = await toggleClubContactPrimaryAction(clubContactId)
+			if (result.success) {
+				toast.success("Primary contact updated")
+				await onRefresh()
+			} else {
+				toast.error(result.error ?? "Failed to update primary contact")
+			}
+		} catch (err) {
+			console.error("Failed to toggle primary:", err)
+			toast.error("Failed to update primary contact")
+		}
+	}
+
+	const existingContactIds = contacts.map((c) => c.contactId)
+
+	return (
+		<Card>
+			<CardHeader className="flex flex-row items-center justify-between">
+				<CardTitle className="font-heading text-xl">Club Contacts</CardTitle>
+				<ContactSearchDialog
+					clubId={clubId}
+					existingContactIds={existingContactIds}
+					onContactAdded={onRefresh}
+				/>
+			</CardHeader>
+			<CardContent className="overflow-x-auto px-0 pb-0">
+				{contacts.length === 0 ? (
+					<p className="px-6 text-sm text-gray-500">No contacts added to this club yet.</p>
+				) : (
+					<Table className="min-w-full divide-y divide-gray-200">
+						<TableHeader className="bg-secondary-50">
+							<TableRow className="hover:bg-secondary-50">
+								<TableHead className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-secondary-900">
+									Name
+								</TableHead>
+								<TableHead className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-secondary-900">
+									Email
+								</TableHead>
+								<TableHead className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-secondary-900">
+									Phone
+								</TableHead>
+								<TableHead className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-secondary-900">
+									Roles
+								</TableHead>
+								<TableHead className="w-10" />
+							</TableRow>
+						</TableHeader>
+						<TableBody className="divide-y divide-gray-100 bg-white">
+							{contacts.map((cc) => {
+								const assignedRoles = cc.roles.map((r) => r.role)
+								const availableRoles = PREDEFINED_ROLES.filter((r) => !assignedRoles.includes(r))
+
+								return (
+									<TableRow key={cc.clubContactId} className="hover:bg-gray-50">
+										<TableCell className="px-4 py-3 text-sm font-medium">
+											<div className="flex items-center gap-1">
+												<button
+													type="button"
+													onClick={() => handleTogglePrimary(cc.clubContactId)}
+													className="shrink-0 rounded p-0.5 hover:bg-gray-100"
+													title={cc.isPrimary ? "Remove primary" : "Set as primary"}
+												>
+													<Star
+														className={`h-4 w-4 ${cc.isPrimary ? "text-yellow-500" : "text-gray-300"}`}
+														fill={cc.isPrimary ? "currentColor" : "none"}
+													/>
+												</button>
+												{cc.firstName} {cc.lastName}
+											</div>
+										</TableCell>
+										<TableCell className="px-4 py-3 text-sm">{cc.email || "-"}</TableCell>
+										<TableCell className="px-4 py-3 text-sm">{cc.primaryPhone || "-"}</TableCell>
+										<TableCell className="px-4 py-3">
+											<div className="flex flex-wrap items-center gap-1">
+												{cc.roles.map((role) => (
+													<Badge
+														key={role.id}
+														variant="outline"
+														className="gap-1 border-secondary-200 bg-secondary-100 pr-1"
+													>
+														{role.role}
+														<button
+															type="button"
+															onClick={() => handleRemoveRole(role.id)}
+															className="ml-0.5 rounded-full p-0.5 hover:bg-gray-200"
+														>
+															<X className="h-3 w-3" />
+														</button>
+													</Badge>
+												))}
+												{availableRoles.length > 0 && mounted && (
+													<Select
+														value=""
+														onValueChange={(value) => handleAddRole(cc.clubContactId, value)}
+													>
+														<SelectTrigger className="h-7 w-[140px] text-xs">
+															<SelectValue placeholder="Add role..." />
+														</SelectTrigger>
+														<SelectContent>
+															{availableRoles.map((role) => (
+																<SelectItem key={role} value={role}>
+																	{role}
+																</SelectItem>
+															))}
+														</SelectContent>
+													</Select>
+												)}
+											</div>
+										</TableCell>
+										<TableCell className="px-4 py-3">
+											<AlertDialog>
+												<AlertDialogTrigger asChild>
+													<Button
+														type="button"
+														variant="ghost"
+														size="sm"
+														disabled={removing === cc.clubContactId}
+													>
+														<Trash2 className="h-4 w-4 text-red-500" />
+													</Button>
+												</AlertDialogTrigger>
+												<AlertDialogContent>
+													<AlertDialogHeader>
+														<AlertDialogTitle>Remove Contact</AlertDialogTitle>
+														<AlertDialogDescription>
+															Remove {cc.firstName} {cc.lastName} from this club? The contact record
+															itself will not be deleted.
+														</AlertDialogDescription>
+													</AlertDialogHeader>
+													<AlertDialogFooter>
+														<AlertDialogCancel>Cancel</AlertDialogCancel>
+														<AlertDialogAction
+															onClick={(e) => {
+																e.preventDefault()
+																handleRemoveContact(cc.clubContactId)
+															}}
+															className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+														>
+															Remove
+														</AlertDialogAction>
+													</AlertDialogFooter>
+												</AlertDialogContent>
+											</AlertDialog>
+										</TableCell>
+									</TableRow>
+								)
+							})}
+						</TableBody>
+					</Table>
+				)}
+			</CardContent>
+		</Card>
+	)
+}

--- a/apps/admin/src/app/(dashboard)/members/clubs/[id]/club-payment-section.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/[id]/club-payment-section.tsx
@@ -30,7 +30,7 @@ export function ClubPaymentSection({
 	membership,
 	onRefresh,
 }: ClubPaymentSectionProps) {
-	const today = new Date().toISOString().split("T")[0]
+	const today = new Date().toLocaleDateString("en-CA")
 	const [paymentDate, setPaymentDate] = useState(today)
 	const [paymentCode, setPaymentCode] = useState("")
 	const [saving, setSaving] = useState(false)

--- a/apps/admin/src/app/(dashboard)/members/clubs/[id]/club-payment-section.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/[id]/club-payment-section.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import {
+	Badge,
+	Button,
+	Card,
+	CardContent,
+	CardHeader,
+	CardTitle,
+	Field,
+	FieldError,
+	FieldLabel,
+	Input,
+	toast,
+} from "@mpga/ui"
+import { useState } from "react"
+
+import { type MembershipData, saveClubPaymentAction } from "../actions"
+
+interface ClubPaymentSectionProps {
+	clubId: number
+	year: number
+	membership: MembershipData | null
+	onRefresh: () => Promise<void>
+}
+
+export function ClubPaymentSection({
+	clubId,
+	year,
+	membership,
+	onRefresh,
+}: ClubPaymentSectionProps) {
+	const today = new Date().toISOString().split("T")[0]
+	const [paymentDate, setPaymentDate] = useState(today)
+	const [paymentCode, setPaymentCode] = useState("")
+	const [saving, setSaving] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+
+	const handleSave = async () => {
+		if (!paymentDate || !paymentCode.trim()) {
+			setError("Payment date and check number are required")
+			return
+		}
+
+		setSaving(true)
+		setError(null)
+
+		try {
+			const result = await saveClubPaymentAction({
+				clubId,
+				paymentDate,
+				paymentCode: paymentCode.trim(),
+			})
+
+			if (result.success) {
+				toast.success("Payment recorded")
+				await onRefresh()
+			} else {
+				setError(result.error ?? "Failed to record payment")
+			}
+		} catch (err) {
+			console.error("Failed to save payment:", err)
+			setError("Failed to record payment")
+		} finally {
+			setSaving(false)
+		}
+	}
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="font-heading text-xl">{year} Season Payment</CardTitle>
+			</CardHeader>
+			<CardContent>
+				{membership ? (
+					<div className="space-y-2">
+						<div className="flex items-center gap-2">
+							<Badge variant="default" className="bg-green-600">
+								Paid
+							</Badge>
+						</div>
+						<p className="text-sm text-gray-700">
+							<span className="font-medium">Payment Date:</span> {membership.paymentDate}
+						</p>
+						<p className="text-sm text-gray-700">
+							<span className="font-medium">Check / Payment Code:</span> {membership.paymentCode}
+						</p>
+					</div>
+				) : (
+					<div className="space-y-4">
+						<div className="flex items-center gap-2">
+							<Badge variant="secondary" className="bg-yellow-100 text-yellow-800">
+								Unpaid
+							</Badge>
+						</div>
+						<div className="grid grid-cols-2 gap-4">
+							<Field>
+								<FieldLabel htmlFor="paymentDate">Payment Date</FieldLabel>
+								<Input
+									id="paymentDate"
+									type="date"
+									value={paymentDate}
+									onChange={(e) => setPaymentDate(e.target.value)}
+								/>
+							</Field>
+							<Field>
+								<FieldLabel htmlFor="paymentCode">Check Number</FieldLabel>
+								<Input
+									id="paymentCode"
+									value={paymentCode}
+									onChange={(e) => setPaymentCode(e.target.value)}
+								/>
+							</Field>
+						</div>
+						{error && <FieldError>{error}</FieldError>}
+						<Button type="button" variant="secondary" disabled={saving} onClick={handleSave}>
+							{saving ? "Recording..." : "Record Payment"}
+						</Button>
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	)
+}

--- a/apps/admin/src/app/(dashboard)/members/clubs/[id]/contact-search-dialog.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/[id]/contact-search-dialog.tsx
@@ -33,6 +33,7 @@ export function ContactSearchDialog({
 	const [results, setResults] = useState<ContactSearchResult[]>([])
 	const [searching, setSearching] = useState(false)
 	const [adding, setAdding] = useState(false)
+	const [error, setError] = useState<string | null>(null)
 	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
 	const doSearch = useCallback(
@@ -67,6 +68,7 @@ export function ContactSearchDialog({
 
 	const handleAdd = async (contactId: number) => {
 		setAdding(true)
+		setError(null)
 		try {
 			const result = await addClubContactAction(clubId, contactId)
 			if (result.success) {
@@ -74,9 +76,12 @@ export function ContactSearchDialog({
 				setSearch("")
 				setResults([])
 				onContactAdded()
+			} else {
+				setError(result.error ?? "Failed to add contact")
 			}
 		} catch (err) {
 			console.error("Failed to add contact:", err)
+			setError("Failed to add contact")
 		} finally {
 			setAdding(false)
 		}
@@ -92,7 +97,7 @@ export function ContactSearchDialog({
 			</AlertDialogTrigger>
 			<AlertDialogContent className="max-w-md">
 				<AlertDialogHeader>
-					<AlertDialogTitle>Search Contacts</AlertDialogTitle>
+					<AlertDialogTitle className="font-heading">Search Contacts</AlertDialogTitle>
 					<AlertDialogDescription>
 						Search by name or email to add a contact to this club.
 					</AlertDialogDescription>
@@ -104,6 +109,8 @@ export function ContactSearchDialog({
 					onChange={(e) => setSearch(e.target.value)}
 					autoFocus
 				/>
+
+				{error && <p className="text-sm text-destructive">{error}</p>}
 
 				<div className="max-h-60 overflow-y-auto">
 					{searching && <p className="py-2 text-center text-sm text-gray-500">Searching...</p>}

--- a/apps/admin/src/app/(dashboard)/members/clubs/[id]/contact-search-dialog.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/[id]/contact-search-dialog.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import {
+	AlertDialog,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+	Button,
+	Input,
+} from "@mpga/ui"
+import { Plus } from "lucide-react"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { type ContactSearchResult, addClubContactAction, searchContactsAction } from "../actions"
+
+interface ContactSearchDialogProps {
+	clubId: number
+	existingContactIds: number[]
+	onContactAdded: () => void
+}
+
+export function ContactSearchDialog({
+	clubId,
+	existingContactIds,
+	onContactAdded,
+}: ContactSearchDialogProps) {
+	const [open, setOpen] = useState(false)
+	const [search, setSearch] = useState("")
+	const [results, setResults] = useState<ContactSearchResult[]>([])
+	const [searching, setSearching] = useState(false)
+	const [adding, setAdding] = useState(false)
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+	const doSearch = useCallback(
+		async (term: string) => {
+			if (!term.trim()) {
+				setResults([])
+				return
+			}
+
+			setSearching(true)
+			try {
+				const result = await searchContactsAction(term)
+				if (result.success && result.data) {
+					setResults(result.data.filter((c) => !existingContactIds.includes(c.id)))
+				}
+			} catch (err) {
+				console.error("Search failed:", err)
+			} finally {
+				setSearching(false)
+			}
+		},
+		[existingContactIds],
+	)
+
+	useEffect(() => {
+		if (timerRef.current) clearTimeout(timerRef.current)
+		timerRef.current = setTimeout(() => doSearch(search), 300)
+		return () => {
+			if (timerRef.current) clearTimeout(timerRef.current)
+		}
+	}, [search, doSearch])
+
+	const handleAdd = async (contactId: number) => {
+		setAdding(true)
+		try {
+			const result = await addClubContactAction(clubId, contactId)
+			if (result.success) {
+				setOpen(false)
+				setSearch("")
+				setResults([])
+				onContactAdded()
+			}
+		} catch (err) {
+			console.error("Failed to add contact:", err)
+		} finally {
+			setAdding(false)
+		}
+	}
+
+	return (
+		<AlertDialog open={open} onOpenChange={setOpen}>
+			<AlertDialogTrigger asChild>
+				<Button type="button" variant="secondary" size="sm">
+					<Plus className="mr-1 h-4 w-4" />
+					Add Contact
+				</Button>
+			</AlertDialogTrigger>
+			<AlertDialogContent className="max-w-md">
+				<AlertDialogHeader>
+					<AlertDialogTitle>Search Contacts</AlertDialogTitle>
+					<AlertDialogDescription>
+						Search by name or email to add a contact to this club.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+
+				<Input
+					placeholder="Search contacts..."
+					value={search}
+					onChange={(e) => setSearch(e.target.value)}
+					autoFocus
+				/>
+
+				<div className="max-h-60 overflow-y-auto">
+					{searching && <p className="py-2 text-center text-sm text-gray-500">Searching...</p>}
+					{!searching && search.trim() && results.length === 0 && (
+						<p className="py-2 text-center text-sm text-gray-500">No contacts found</p>
+					)}
+					{results.map((c) => (
+						<button
+							key={c.id}
+							type="button"
+							disabled={adding}
+							onClick={() => handleAdd(c.id)}
+							className="w-full rounded-md px-3 py-2 text-left text-sm hover:bg-gray-100 disabled:opacity-50"
+						>
+							<span className="font-medium">
+								{c.firstName} {c.lastName}
+							</span>
+							{c.email && <span className="ml-2 text-gray-500">{c.email}</span>}
+						</button>
+					))}
+				</div>
+
+				<AlertDialogFooter>
+					<AlertDialogCancel>Close</AlertDialogCancel>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	)
+}

--- a/apps/admin/src/app/(dashboard)/members/clubs/[id]/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/[id]/page.tsx
@@ -31,16 +31,24 @@ export default function EditClubPage() {
 	const currentYear = new Date().getFullYear()
 
 	const fetchContacts = useCallback(async () => {
-		const result = await listClubContactsAction(clubId)
-		if (result.success && result.data) {
-			setContacts(result.data)
+		try {
+			const result = await listClubContactsAction(clubId)
+			if (result.success && result.data) {
+				setContacts(result.data)
+			}
+		} catch (err) {
+			console.error("Failed to fetch contacts:", err)
 		}
 	}, [clubId])
 
 	const fetchMembership = useCallback(async () => {
-		const result = await getClubMembershipAction(clubId, currentYear)
-		if (result.success) {
-			setMembershipData(result.data ?? null)
+		try {
+			const result = await getClubMembershipAction(clubId, currentYear)
+			if (result.success) {
+				setMembershipData(result.data ?? null)
+			}
+		} catch (err) {
+			console.error("Failed to fetch membership:", err)
 		}
 	}, [clubId, currentYear])
 

--- a/apps/admin/src/app/(dashboard)/members/clubs/[id]/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/[id]/page.tsx
@@ -1,0 +1,107 @@
+"use client"
+
+import { EmptyState, H1 } from "@mpga/ui"
+import { useParams, useRouter } from "next/navigation"
+import { useCallback, useEffect, useState } from "react"
+
+import {
+	type ClubContactData,
+	type ClubData,
+	type GolfCourseOption,
+	type MembershipData,
+	getClubAction,
+	getClubMembershipAction,
+	listClubContactsAction,
+	listGolfCourseOptionsAction,
+} from "../actions"
+import { ClubForm } from "../club-form"
+import { ClubContactsSection } from "./club-contacts-section"
+import { ClubPaymentSection } from "./club-payment-section"
+
+export default function EditClubPage() {
+	const params = useParams()
+	const router = useRouter()
+	const [club, setClub] = useState<ClubData | null>(null)
+	const [golfCourses, setGolfCourses] = useState<GolfCourseOption[]>([])
+	const [contacts, setContacts] = useState<ClubContactData[]>([])
+	const [membershipData, setMembershipData] = useState<MembershipData | null>(null)
+	const [loading, setLoading] = useState(true)
+
+	const clubId = Number(params.id)
+	const currentYear = new Date().getFullYear()
+
+	const fetchContacts = useCallback(async () => {
+		const result = await listClubContactsAction(clubId)
+		if (result.success && result.data) {
+			setContacts(result.data)
+		}
+	}, [clubId])
+
+	const fetchMembership = useCallback(async () => {
+		const result = await getClubMembershipAction(clubId, currentYear)
+		if (result.success) {
+			setMembershipData(result.data ?? null)
+		}
+	}, [clubId, currentYear])
+
+	useEffect(() => {
+		if (isNaN(clubId)) {
+			router.push("/members/clubs")
+			return
+		}
+
+		async function fetchAll() {
+			try {
+				const [clubResult, coursesResult] = await Promise.all([
+					getClubAction(clubId),
+					listGolfCourseOptionsAction(),
+				])
+
+				if (!clubResult.success || !clubResult.data) {
+					router.push("/members/clubs")
+					return
+				}
+
+				setClub(clubResult.data)
+				if (coursesResult.success && coursesResult.data) {
+					setGolfCourses(coursesResult.data)
+				}
+
+				await Promise.all([fetchContacts(), fetchMembership()])
+			} catch (err) {
+				console.error("Failed to load club:", err)
+				router.push("/members/clubs")
+			} finally {
+				setLoading(false)
+			}
+		}
+
+		fetchAll()
+	}, [clubId, router, fetchContacts, fetchMembership])
+
+	if (loading) {
+		return (
+			<div className="mx-auto max-w-6xl">
+				<EmptyState message="Loading club..." />
+			</div>
+		)
+	}
+
+	if (!club) {
+		return null
+	}
+
+	return (
+		<div className="mx-auto max-w-6xl space-y-6">
+			<H1 variant="secondary">Edit Club</H1>
+			<ClubForm club={club} golfCourses={golfCourses} />
+			<ClubContactsSection clubId={clubId} contacts={contacts} onRefresh={fetchContacts} />
+			<ClubPaymentSection
+				clubId={clubId}
+				year={currentYear}
+				membership={membershipData}
+				onRefresh={fetchMembership}
+			/>
+		</div>
+	)
+}

--- a/apps/admin/src/app/(dashboard)/members/clubs/actions.ts
+++ b/apps/admin/src/app/(dashboard)/members/clubs/actions.ts
@@ -1,0 +1,501 @@
+"use server"
+
+import { club, clubContact, clubContactRole, contact, golfCourse, membership } from "@mpga/database"
+import type { ActionResult } from "@mpga/types"
+import { and, asc, eq, like, or, sql } from "drizzle-orm"
+
+import { db } from "@/lib/db"
+import { requireAuth } from "@/lib/require-auth"
+
+// ── Types ───────────────────────────────────────────────────────────
+
+interface ClubInput {
+	id?: number
+	name: string
+	website: string
+	golfCourseId: number | null
+	size: number | null
+	archived: boolean
+	notes?: string | null
+}
+
+export interface ClubData {
+	id: number
+	name: string
+	website: string
+	golfCourseId: number | null
+	golfCourseName: string | null
+	size: number | null
+	archived: boolean
+	notes: string | null
+	isMember: boolean
+}
+
+export interface GolfCourseOption {
+	id: number
+	name: string
+}
+
+export interface ClubContactData {
+	clubContactId: number
+	contactId: number
+	firstName: string
+	lastName: string
+	email: string | null
+	primaryPhone: string | null
+	isPrimary: boolean
+	roles: { id: number; role: string }[]
+}
+
+export interface ContactSearchResult {
+	id: number
+	firstName: string
+	lastName: string
+	email: string | null
+}
+
+export interface MembershipData {
+	id: number
+	year: number
+	paymentDate: string
+	paymentType: string
+	paymentCode: string
+}
+
+// ── Club CRUD ───────────────────────────────────────────────────────
+
+export async function listClubsAction(): Promise<ActionResult<ClubData[]>> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	const currentYear = new Date().getFullYear()
+
+	try {
+		const rows = await db
+			.select({
+				id: club.id,
+				name: club.name,
+				website: club.website,
+				golfCourseId: club.golfCourseId,
+				golfCourseName: golfCourse.name,
+				size: club.size,
+				archived: club.archived,
+				notes: club.notes,
+				membershipId: membership.id,
+			})
+			.from(club)
+			.leftJoin(golfCourse, eq(club.golfCourseId, golfCourse.id))
+			.leftJoin(membership, and(eq(membership.clubId, club.id), eq(membership.year, currentYear)))
+			.orderBy(asc(club.name))
+
+		const results: ClubData[] = rows.map((row) => ({
+			id: row.id,
+			name: row.name,
+			website: row.website,
+			golfCourseId: row.golfCourseId,
+			golfCourseName: row.golfCourseName,
+			size: row.size,
+			archived: row.archived,
+			notes: row.notes,
+			isMember: row.membershipId !== null,
+		}))
+
+		return { success: true, data: results }
+	} catch (error) {
+		console.error("Failed to list clubs:", error)
+		return { success: false, error: "Failed to list clubs" }
+	}
+}
+
+export async function getClubAction(id: number): Promise<ActionResult<ClubData>> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	const currentYear = new Date().getFullYear()
+
+	try {
+		const rows = await db
+			.select({
+				id: club.id,
+				name: club.name,
+				website: club.website,
+				golfCourseId: club.golfCourseId,
+				golfCourseName: golfCourse.name,
+				size: club.size,
+				archived: club.archived,
+				notes: club.notes,
+				membershipId: membership.id,
+			})
+			.from(club)
+			.leftJoin(golfCourse, eq(club.golfCourseId, golfCourse.id))
+			.leftJoin(membership, and(eq(membership.clubId, club.id), eq(membership.year, currentYear)))
+			.where(eq(club.id, id))
+
+		const row = rows[0]
+		if (!row) {
+			return { success: false, error: "Club not found" }
+		}
+
+		return {
+			success: true,
+			data: {
+				id: row.id,
+				name: row.name,
+				website: row.website,
+				golfCourseId: row.golfCourseId,
+				golfCourseName: row.golfCourseName,
+				size: row.size,
+				archived: row.archived,
+				notes: row.notes,
+				isMember: row.membershipId !== null,
+			},
+		}
+	} catch (error) {
+		console.error("Failed to get club:", error)
+		return { success: false, error: "Failed to get club" }
+	}
+}
+
+export async function saveClubAction(data: ClubInput): Promise<ActionResult<{ id: number }>> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	const name = data.name?.trim()
+
+	if (!name) {
+		return { success: false, error: "Name is required" }
+	}
+
+	try {
+		if (data.id !== undefined) {
+			await db
+				.update(club)
+				.set({
+					name,
+					website: data.website,
+					golfCourseId: data.golfCourseId,
+					size: data.size,
+					archived: data.archived,
+					notes: data.notes ?? null,
+				})
+				.where(eq(club.id, data.id))
+
+			return { success: true, data: { id: data.id } }
+		} else {
+			const result = await db.insert(club).values({
+				name,
+				website: data.website,
+				golfCourseId: data.golfCourseId,
+				size: data.size,
+				archived: data.archived,
+				notes: data.notes ?? null,
+			})
+
+			return { success: true, data: { id: result[0].insertId } }
+		}
+	} catch (error) {
+		console.error("Failed to save club:", error)
+		return { success: false, error: "Failed to save club" }
+	}
+}
+
+export async function listGolfCourseOptionsAction(): Promise<ActionResult<GolfCourseOption[]>> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	try {
+		const results = await db
+			.select({
+				id: golfCourse.id,
+				name: golfCourse.name,
+			})
+			.from(golfCourse)
+			.orderBy(asc(golfCourse.name))
+
+		return { success: true, data: results }
+	} catch (error) {
+		console.error("Failed to list golf courses:", error)
+		return { success: false, error: "Failed to list golf courses" }
+	}
+}
+
+// ── Club Contacts ───────────────────────────────────────────────────
+
+export async function listClubContactsAction(
+	clubId: number,
+): Promise<ActionResult<ClubContactData[]>> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	try {
+		const contactRows = await db
+			.select({
+				clubContactId: clubContact.id,
+				contactId: contact.id,
+				firstName: contact.firstName,
+				lastName: contact.lastName,
+				email: contact.email,
+				primaryPhone: contact.primaryPhone,
+				isPrimary: clubContact.isPrimary,
+			})
+			.from(clubContact)
+			.innerJoin(contact, eq(clubContact.contactId, contact.id))
+			.where(eq(clubContact.clubId, clubId))
+			.orderBy(asc(contact.lastName), asc(contact.firstName))
+
+		const clubContactIds = contactRows.map((r) => r.clubContactId)
+
+		let roleRows: { id: number; role: string; clubContactId: number }[] = []
+		if (clubContactIds.length > 0) {
+			roleRows = await db
+				.select({
+					id: clubContactRole.id,
+					role: clubContactRole.role,
+					clubContactId: clubContactRole.clubContactId,
+				})
+				.from(clubContactRole)
+				.where(or(...clubContactIds.map((ccId) => eq(clubContactRole.clubContactId, ccId))))
+		}
+
+		const data: ClubContactData[] = contactRows.map((row) => ({
+			...row,
+			roles: roleRows
+				.filter((r) => r.clubContactId === row.clubContactId)
+				.map((r) => ({ id: r.id, role: r.role })),
+		}))
+
+		return { success: true, data }
+	} catch (error) {
+		console.error("Failed to list club contacts:", error)
+		return { success: false, error: "Failed to list club contacts" }
+	}
+}
+
+export async function addClubContactAction(
+	clubId: number,
+	contactId: number,
+): Promise<ActionResult<{ id: number }>> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	try {
+		const existing = await db
+			.select({ id: clubContact.id })
+			.from(clubContact)
+			.where(and(eq(clubContact.clubId, clubId), eq(clubContact.contactId, contactId)))
+
+		if (existing.length > 0) {
+			return { success: false, error: "Contact is already a member of this club" }
+		}
+
+		const result = await db.insert(clubContact).values({
+			clubId,
+			contactId,
+			isPrimary: false,
+		})
+
+		return { success: true, data: { id: result[0].insertId } }
+	} catch (error) {
+		console.error("Failed to add club contact:", error)
+		return { success: false, error: "Failed to add club contact" }
+	}
+}
+
+export async function removeClubContactAction(clubContactId: number): Promise<ActionResult> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	try {
+		// Delete roles first due to FK constraint
+		await db.delete(clubContactRole).where(eq(clubContactRole.clubContactId, clubContactId))
+		await db.delete(clubContact).where(eq(clubContact.id, clubContactId))
+		return { success: true }
+	} catch (error) {
+		console.error("Failed to remove club contact:", error)
+		return { success: false, error: "Failed to remove club contact" }
+	}
+}
+
+export async function searchContactsAction(
+	term: string,
+): Promise<ActionResult<ContactSearchResult[]>> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	const search = `%${term.trim()}%`
+	if (!term.trim()) {
+		return { success: true, data: [] }
+	}
+
+	try {
+		const results = await db
+			.select({
+				id: contact.id,
+				firstName: contact.firstName,
+				lastName: contact.lastName,
+				email: contact.email,
+			})
+			.from(contact)
+			.where(
+				or(
+					like(contact.firstName, search),
+					like(contact.lastName, search),
+					like(contact.email, search),
+				),
+			)
+			.orderBy(asc(contact.lastName), asc(contact.firstName))
+			.limit(20)
+
+		return { success: true, data: results }
+	} catch (error) {
+		console.error("Failed to search contacts:", error)
+		return { success: false, error: "Failed to search contacts" }
+	}
+}
+
+export async function toggleClubContactPrimaryAction(clubContactId: number): Promise<ActionResult> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	try {
+		const rows = await db
+			.select({ isPrimary: clubContact.isPrimary })
+			.from(clubContact)
+			.where(eq(clubContact.id, clubContactId))
+
+		const row = rows[0]
+		if (!row) {
+			return { success: false, error: "Club contact not found" }
+		}
+
+		await db
+			.update(clubContact)
+			.set({ isPrimary: !row.isPrimary })
+			.where(eq(clubContact.id, clubContactId))
+
+		return { success: true }
+	} catch (error) {
+		console.error("Failed to toggle primary contact:", error)
+		return { success: false, error: "Failed to toggle primary contact" }
+	}
+}
+
+// ── Club Contact Roles ──────────────────────────────────────────────
+
+export async function addClubContactRoleAction(
+	clubContactId: number,
+	role: string,
+): Promise<ActionResult<{ id: number }>> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	try {
+		const result = await db.insert(clubContactRole).values({
+			clubContactId,
+			role,
+		})
+
+		return { success: true, data: { id: result[0].insertId } }
+	} catch (error) {
+		console.error("Failed to add role:", error)
+		return { success: false, error: "Failed to add role" }
+	}
+}
+
+export async function removeClubContactRoleAction(roleId: number): Promise<ActionResult> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	try {
+		await db.delete(clubContactRole).where(eq(clubContactRole.id, roleId))
+		return { success: true }
+	} catch (error) {
+		console.error("Failed to remove role:", error)
+		return { success: false, error: "Failed to remove role" }
+	}
+}
+
+// ── Membership / Season Payment ─────────────────────────────────────
+
+export async function getClubMembershipAction(
+	clubId: number,
+	year: number,
+): Promise<ActionResult<MembershipData | null>> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	try {
+		const results = await db
+			.select({
+				id: membership.id,
+				year: membership.year,
+				paymentDate: membership.paymentDate,
+				paymentType: membership.paymentType,
+				paymentCode: membership.paymentCode,
+			})
+			.from(membership)
+			.where(and(eq(membership.clubId, clubId), eq(membership.year, year)))
+
+		if (results.length === 0) {
+			return { success: true, data: null }
+		}
+
+		return { success: true, data: results[0] }
+	} catch (error) {
+		console.error("Failed to get club membership:", error)
+		return { success: false, error: "Failed to get club membership" }
+	}
+}
+
+export async function saveClubPaymentAction(data: {
+	clubId: number
+	paymentDate: string
+	paymentCode: string
+}): Promise<ActionResult<{ id: number }>> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	const currentYear = new Date().getFullYear()
+
+	try {
+		const result = await db.insert(membership).values({
+			clubId: data.clubId,
+			year: currentYear,
+			paymentDate: data.paymentDate,
+			paymentType: "CK",
+			paymentCode: data.paymentCode,
+			createDate: sql`NOW(6)`,
+		})
+
+		return { success: true, data: { id: result[0].insertId } }
+	} catch (error) {
+		console.error("Failed to save payment:", error)
+		return { success: false, error: "Failed to save payment" }
+	}
+}

--- a/apps/admin/src/app/(dashboard)/members/clubs/club-form.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/club-form.tsx
@@ -1,0 +1,199 @@
+"use client"
+
+import {
+	Button,
+	Card,
+	CardContent,
+	CardHeader,
+	CardTitle,
+	Checkbox,
+	Field,
+	FieldError,
+	FieldLabel,
+	Input,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+	toast,
+} from "@mpga/ui"
+import { useRouter } from "next/navigation"
+import { useEffect, useState } from "react"
+
+import { MarkdownEditor } from "@/components/markdown-editor"
+
+import { type ClubData, type GolfCourseOption, saveClubAction } from "./actions"
+
+interface ClubFormProps {
+	club?: ClubData
+	golfCourses: GolfCourseOption[]
+}
+
+export function ClubForm({ club: existingClub, golfCourses }: ClubFormProps) {
+	const router = useRouter()
+	const [mounted, setMounted] = useState(false)
+	const [saving, setSaving] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+
+	useEffect(() => setMounted(true), [])
+
+	const [name, setName] = useState(existingClub?.name ?? "")
+	const [website, setWebsite] = useState(existingClub?.website ?? "")
+	const [golfCourseId, setGolfCourseId] = useState<number | null>(
+		existingClub?.golfCourseId ?? null,
+	)
+	const [size, setSize] = useState<string>(existingClub?.size?.toString() ?? "")
+	const [archived, setArchived] = useState(existingClub?.archived ?? false)
+	const [notes, setNotes] = useState(existingClub?.notes ?? "")
+
+	const handleSave = async (e: React.FormEvent) => {
+		e.preventDefault()
+
+		if (!name.trim()) {
+			setError("Name is required")
+			return
+		}
+
+		setSaving(true)
+		setError(null)
+
+		try {
+			const result = await saveClubAction({
+				id: existingClub?.id,
+				name: name.trim(),
+				website: website.trim(),
+				golfCourseId,
+				size: size ? parseInt(size, 10) : null,
+				archived,
+				notes: notes.trim() || null,
+			})
+
+			if (result.success && result.data) {
+				if (existingClub) {
+					toast.success("Club updated")
+				} else {
+					toast.success("Club created")
+					router.push(`/members/clubs/${result.data.id}`)
+				}
+			} else {
+				setError(result.error ?? "Failed to save club")
+			}
+		} catch (err) {
+			console.error("Failed to save club:", err)
+			setError("Failed to save club")
+		} finally {
+			setSaving(false)
+		}
+	}
+
+	const handleCancel = () => {
+		router.push("/members/clubs")
+	}
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="font-heading text-xl">Club Information</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<form onSubmit={handleSave}>
+					<div className="grid grid-cols-[30%_1fr] gap-6">
+						{/* Left column */}
+						<div className="space-y-4">
+							{/* Name */}
+							<Field>
+								<FieldLabel htmlFor="name">
+									Name <span className="text-destructive">*</span>
+								</FieldLabel>
+								<Input id="name" value={name} onChange={(e) => setName(e.target.value)} required />
+							</Field>
+
+							{/* Website */}
+							<Field>
+								<FieldLabel htmlFor="website">Website</FieldLabel>
+								<Input id="website" value={website} onChange={(e) => setWebsite(e.target.value)} />
+							</Field>
+
+							{/* Golf Course dropdown */}
+							<Field>
+								<FieldLabel>Golf Course</FieldLabel>
+								{mounted ? (
+									<Select
+										value={golfCourseId !== null ? String(golfCourseId) : "none"}
+										onValueChange={(value) =>
+											setGolfCourseId(value === "none" ? null : parseInt(value, 10))
+										}
+									>
+										<SelectTrigger>
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="none">None</SelectItem>
+											{golfCourses.map((course) => (
+												<SelectItem key={course.id} value={String(course.id)}>
+													{course.name}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								) : (
+									<div className="h-9 rounded-md border bg-transparent" />
+								)}
+							</Field>
+
+							{/* Size */}
+							<Field>
+								<FieldLabel htmlFor="size">Size</FieldLabel>
+								<Input
+									id="size"
+									type="number"
+									value={size}
+									onChange={(e) => setSize(e.target.value)}
+								/>
+							</Field>
+
+							{/* Archived */}
+							<Field orientation="horizontal">
+								<Checkbox
+									id="archived"
+									checked={archived}
+									onCheckedChange={(checked) => setArchived(checked === true)}
+								/>
+								<FieldLabel htmlFor="archived" className="mb-0">
+									Archived
+								</FieldLabel>
+							</Field>
+						</div>
+
+						{/* Right column */}
+						<div>
+							<FieldLabel>Notes</FieldLabel>
+							<MarkdownEditor
+								value={notes}
+								onChange={setNotes}
+								minHeight="200px"
+								maxHeight="400px"
+							/>
+						</div>
+					</div>
+
+					{/* Error message */}
+					{error && <FieldError className="mt-4">{error}</FieldError>}
+
+					{/* Action buttons */}
+					<div className="flex justify-end pt-6">
+						<div className="flex gap-2">
+							<Button type="button" variant="secondaryoutline" onClick={handleCancel}>
+								Cancel
+							</Button>
+							<Button type="submit" variant="secondary" disabled={saving}>
+								{saving ? "Saving..." : "Save"}
+							</Button>
+						</div>
+					</div>
+				</form>
+			</CardContent>
+		</Card>
+	)
+}

--- a/apps/admin/src/app/(dashboard)/members/clubs/club-form.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/club-form.tsx
@@ -64,7 +64,7 @@ export function ClubForm({ club: existingClub, golfCourses }: ClubFormProps) {
 				name: name.trim(),
 				website: website.trim(),
 				golfCourseId,
-				size: size ? parseInt(size, 10) : null,
+				size: size ? (Number.isNaN(parseInt(size, 10)) ? null : parseInt(size, 10)) : null,
 				archived,
 				notes: notes.trim() || null,
 			})

--- a/apps/admin/src/app/(dashboard)/members/clubs/new/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/new/page.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { EmptyState, H1 } from "@mpga/ui"
+import { useEffect, useState } from "react"
+
+import { type GolfCourseOption, listGolfCourseOptionsAction } from "../actions"
+import { ClubForm } from "../club-form"
+
+export default function NewClubPage() {
+	const [golfCourses, setGolfCourses] = useState<GolfCourseOption[]>([])
+	const [loading, setLoading] = useState(true)
+
+	useEffect(() => {
+		async function fetchOptions() {
+			try {
+				const result = await listGolfCourseOptionsAction()
+				if (result.success && result.data) {
+					setGolfCourses(result.data)
+				}
+			} catch (err) {
+				console.error("Failed to fetch golf courses:", err)
+			} finally {
+				setLoading(false)
+			}
+		}
+
+		fetchOptions()
+	}, [])
+
+	if (loading) {
+		return (
+			<div className="mx-auto max-w-6xl">
+				<EmptyState message="Loading..." />
+			</div>
+		)
+	}
+
+	return (
+		<div className="mx-auto max-w-6xl">
+			<H1 variant="secondary" className="mb-6">
+				New Club
+			</H1>
+			<ClubForm golfCourses={golfCourses} />
+		</div>
+	)
+}

--- a/apps/admin/src/app/(dashboard)/members/clubs/new/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/new/page.tsx
@@ -9,6 +9,7 @@ import { ClubForm } from "../club-form"
 export default function NewClubPage() {
 	const [golfCourses, setGolfCourses] = useState<GolfCourseOption[]>([])
 	const [loading, setLoading] = useState(true)
+	const [error, setError] = useState<string | null>(null)
 
 	useEffect(() => {
 		async function fetchOptions() {
@@ -16,9 +17,12 @@ export default function NewClubPage() {
 				const result = await listGolfCourseOptionsAction()
 				if (result.success && result.data) {
 					setGolfCourses(result.data)
+				} else {
+					setError(result.error ?? "Failed to load golf course options")
 				}
 			} catch (err) {
 				console.error("Failed to fetch golf courses:", err)
+				setError("Failed to load golf course options")
 			} finally {
 				setLoading(false)
 			}
@@ -31,6 +35,14 @@ export default function NewClubPage() {
 		return (
 			<div className="mx-auto max-w-6xl">
 				<EmptyState message="Loading..." />
+			</div>
+		)
+	}
+
+	if (error) {
+		return (
+			<div className="mx-auto max-w-6xl">
+				<EmptyState message={error} />
 			</div>
 		)
 	}

--- a/apps/admin/src/app/(dashboard)/members/clubs/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/page.tsx
@@ -99,6 +99,7 @@ export default function ClubsPage() {
 	const router = useRouter()
 	const [clubs, setClubs] = useState<ClubData[]>([])
 	const [loading, setLoading] = useState(true)
+	const [error, setError] = useState<string | null>(null)
 	const [globalFilter, setGlobalFilter] = useState("")
 	const [sorting, setSorting] = useState<SortingState>([{ id: "name", desc: false }])
 	const [pagination, setPagination] = useState<PaginationState>({
@@ -113,9 +114,12 @@ export default function ClubsPage() {
 				const result = await listClubsAction()
 				if (result.success && result.data) {
 					setClubs(result.data)
+				} else {
+					setError(result.error ?? "Failed to load clubs")
 				}
 			} catch (err) {
 				console.error("Failed to fetch clubs:", err)
+				setError("Failed to load clubs")
 			} finally {
 				setLoading(false)
 			}
@@ -167,6 +171,8 @@ export default function ClubsPage() {
 
 			{loading ? (
 				<EmptyState message="Loading clubs..." />
+			) : error ? (
+				<EmptyState message={error} />
 			) : clubs.length === 0 ? (
 				<EmptyState message="No clubs found" />
 			) : (

--- a/apps/admin/src/app/(dashboard)/members/clubs/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/page.tsx
@@ -1,14 +1,261 @@
-import { H1 } from "@mpga/ui"
+"use client"
+
+import {
+	Badge,
+	Button,
+	Card,
+	EmptyState,
+	H1,
+	PageSizeSelect,
+	Pagination,
+	SearchInput,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@mpga/ui"
+import {
+	type Column,
+	type ColumnDef,
+	type FilterFn,
+	type PaginationState,
+	type SortingState,
+	flexRender,
+	getCoreRowModel,
+	getFilteredRowModel,
+	getPaginationRowModel,
+	getSortedRowModel,
+	useReactTable,
+} from "@tanstack/react-table"
+import { ChevronDown, ChevronUp, ChevronsUpDown } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { useEffect, useState } from "react"
+
+import { type ClubData, listClubsAction } from "./actions"
+
+const clubGlobalFilterFn: FilterFn<ClubData> = (row, _columnId, filterValue) => {
+	const term = (filterValue as string).toLowerCase()
+	if (!term) return true
+
+	const c = row.original
+	return (
+		c.name.toLowerCase().includes(term) ||
+		(c.golfCourseName ?? "").toLowerCase().includes(term) ||
+		c.website.toLowerCase().includes(term)
+	)
+}
+
+const columns: ColumnDef<ClubData>[] = [
+	{
+		accessorKey: "name",
+		header: "Name",
+		cell: ({ getValue }) => <span className="font-medium">{getValue<string>()}</span>,
+	},
+	{
+		accessorKey: "golfCourseName",
+		header: "Golf Course",
+		cell: ({ getValue }) => getValue<string | null>() || "-",
+	},
+	{
+		accessorKey: "website",
+		header: "Website",
+		enableSorting: false,
+		cell: ({ getValue }) => getValue<string>() || "-",
+	},
+	{
+		accessorKey: "size",
+		header: "Size",
+		cell: ({ getValue }) => getValue<number | null>() ?? "-",
+	},
+	{
+		accessorKey: "isMember",
+		header: "Member",
+		cell: ({ getValue }) =>
+			getValue<boolean>() ? (
+				<Badge variant="default" className="bg-green-600">
+					Member
+				</Badge>
+			) : (
+				<Badge variant="secondary">No</Badge>
+			),
+	},
+]
+
+function SortIcon({ column }: { column: Column<ClubData> }) {
+	const sorted = column.getIsSorted()
+	if (!sorted) {
+		return <ChevronsUpDown className="ml-1 inline h-4 w-4 opacity-50" />
+	}
+	return sorted === "asc" ? (
+		<ChevronUp className="ml-1 inline h-4 w-4" />
+	) : (
+		<ChevronDown className="ml-1 inline h-4 w-4" />
+	)
+}
 
 export default function ClubsPage() {
+	const router = useRouter()
+	const [clubs, setClubs] = useState<ClubData[]>([])
+	const [loading, setLoading] = useState(true)
+	const [globalFilter, setGlobalFilter] = useState("")
+	const [sorting, setSorting] = useState<SortingState>([{ id: "name", desc: false }])
+	const [pagination, setPagination] = useState<PaginationState>({
+		pageIndex: 0,
+		pageSize: 25,
+	})
+	const [pageSizeOption, setPageSizeOption] = useState<string>("25")
+
+	useEffect(() => {
+		async function fetchClubs() {
+			try {
+				const result = await listClubsAction()
+				if (result.success && result.data) {
+					setClubs(result.data)
+				}
+			} catch (err) {
+				console.error("Failed to fetch clubs:", err)
+			} finally {
+				setLoading(false)
+			}
+		}
+
+		fetchClubs()
+	}, [])
+
+	const table = useReactTable({
+		data: clubs,
+		columns,
+		state: {
+			sorting,
+			globalFilter,
+			pagination,
+		},
+		onSortingChange: setSorting,
+		onGlobalFilterChange: setGlobalFilter,
+		onPaginationChange: setPagination,
+		globalFilterFn: clubGlobalFilterFn,
+		autoResetPageIndex: true,
+		getCoreRowModel: getCoreRowModel(),
+		getFilteredRowModel: getFilteredRowModel(),
+		getSortedRowModel: getSortedRowModel(),
+		getPaginationRowModel: getPaginationRowModel(),
+	})
+
+	const handlePageSizeChange = (value: string) => {
+		setPageSizeOption(value)
+		if (value === "all") {
+			table.setPageSize(clubs.length || 1)
+		} else {
+			table.setPageSize(Number(value))
+		}
+		table.setPageIndex(0)
+	}
+
+	const filteredCount = table.getFilteredRowModel().rows.length
+	const showPagination = pageSizeOption !== "all" && table.getPageCount() > 1
+
 	return (
 		<div className="mx-auto max-w-6xl">
-			<H1 variant="secondary" className="mb-6">
-				Clubs
-			</H1>
-			<div className="rounded-lg border bg-white p-6">
-				<p className="text-gray-500">Clubs management coming soon.</p>
+			<div className="mb-6 flex items-center justify-between">
+				<H1 variant="secondary">Clubs</H1>
+				<Button variant="secondary" onClick={() => router.push("/members/clubs/new")}>
+					Add Club
+				</Button>
 			</div>
+
+			{loading ? (
+				<EmptyState message="Loading clubs..." />
+			) : clubs.length === 0 ? (
+				<EmptyState message="No clubs found" />
+			) : (
+				<div className="space-y-4">
+					{/* Controls row */}
+					<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+						<SearchInput
+							variant="secondary"
+							placeholder="Search clubs..."
+							value={globalFilter}
+							onChange={(e) => setGlobalFilter(e.target.value)}
+						/>
+						<div className="flex items-center gap-4">
+							<PageSizeSelect
+								value={pageSizeOption}
+								onChange={handlePageSizeChange}
+								options={[10, 25, 50, 100, "all"]}
+							/>
+							<p className="text-sm text-gray-600">
+								{filteredCount} {filteredCount === 1 ? "club" : "clubs"}
+								{globalFilter && ` (filtered)`}
+							</p>
+						</div>
+					</div>
+
+					{filteredCount === 0 ? (
+						<EmptyState message="No clubs match your search" />
+					) : (
+						<>
+							{/* Table */}
+							<Card className="overflow-x-auto p-0">
+								<Table className="min-w-full divide-y divide-gray-200">
+									<TableHeader className="bg-secondary-50">
+										<TableRow className="hover:bg-secondary-50">
+											{table.getHeaderGroups().map((headerGroup) =>
+												headerGroup.headers.map((header) => (
+													<TableHead
+														key={header.id}
+														className={`px-4 py-3 text-xs font-semibold uppercase tracking-wider text-secondary-900${
+															header.column.getCanSort()
+																? " cursor-pointer transition-colors hover:bg-secondary-100"
+																: ""
+														}`}
+														onClick={header.column.getToggleSortingHandler()}
+													>
+														{header.column.getCanSort() ? (
+															<span className="flex items-center gap-1">
+																{flexRender(header.column.columnDef.header, header.getContext())}
+																<SortIcon column={header.column} />
+															</span>
+														) : (
+															flexRender(header.column.columnDef.header, header.getContext())
+														)}
+													</TableHead>
+												)),
+											)}
+										</TableRow>
+									</TableHeader>
+									<TableBody className="divide-y divide-gray-100 bg-white">
+										{table.getRowModel().rows.map((row) => (
+											<TableRow
+												key={row.original.id}
+												className="cursor-pointer hover:bg-gray-50"
+												onClick={() => router.push(`/members/clubs/${row.original.id}`)}
+											>
+												{row.getVisibleCells().map((cell) => (
+													<TableCell key={cell.id} className="px-4 py-3 text-sm">
+														{flexRender(cell.column.columnDef.cell, cell.getContext())}
+													</TableCell>
+												))}
+											</TableRow>
+										))}
+									</TableBody>
+								</Table>
+							</Card>
+
+							{/* Pagination */}
+							{showPagination && (
+								<Pagination
+									currentPage={table.getState().pagination.pageIndex + 1}
+									totalPages={table.getPageCount()}
+									onPreviousPage={() => table.previousPage()}
+									onNextPage={() => table.nextPage()}
+								/>
+							)}
+						</>
+					)}
+				</div>
+			)}
 		</div>
 	)
 }

--- a/apps/admin/src/app/(dashboard)/members/golf-courses/[id]/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/golf-courses/[id]/page.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { H1 } from "@mpga/ui"
+import { useParams, useRouter } from "next/navigation"
+import { useEffect, useState } from "react"
+
+import { type GolfCourseData, getGolfCourseAction } from "../actions"
+import { GolfCourseForm } from "../golf-course-form"
+
+export default function EditGolfCoursePage() {
+	const params = useParams()
+	const router = useRouter()
+	const [golfCourse, setGolfCourse] = useState<GolfCourseData | null>(null)
+	const [loading, setLoading] = useState(true)
+
+	useEffect(() => {
+		async function fetchGolfCourse() {
+			const id = Number(params.id)
+			if (isNaN(id)) {
+				router.push("/members/golf-courses")
+				return
+			}
+
+			try {
+				const result = await getGolfCourseAction(id)
+				if (result.success && result.data) {
+					setGolfCourse(result.data)
+				} else {
+					router.push("/members/golf-courses")
+				}
+			} catch (err) {
+				console.error("Failed to fetch golf course:", err)
+				router.push("/members/golf-courses")
+			} finally {
+				setLoading(false)
+			}
+		}
+
+		fetchGolfCourse()
+	}, [params.id, router])
+
+	if (loading) {
+		return (
+			<div className="mx-auto max-w-4xl">
+				<div className="py-8 text-center text-gray-500">Loading golf course...</div>
+			</div>
+		)
+	}
+
+	if (!golfCourse) {
+		return null
+	}
+
+	return (
+		<div className="mx-auto max-w-4xl">
+			<H1 variant="secondary" className="mb-6">
+				Edit Golf Course
+			</H1>
+			<GolfCourseForm golfCourse={golfCourse} />
+		</div>
+	)
+}

--- a/apps/admin/src/app/(dashboard)/members/golf-courses/actions.ts
+++ b/apps/admin/src/app/(dashboard)/members/golf-courses/actions.ts
@@ -1,0 +1,180 @@
+"use server"
+
+import { golfCourse } from "@mpga/database"
+import type { ActionResult } from "@mpga/types"
+import { asc, eq } from "drizzle-orm"
+
+import { db } from "@/lib/db"
+import { requireAuth } from "@/lib/require-auth"
+
+interface GolfCourseInput {
+	id?: number
+	name: string
+	addressText: string
+	city: string
+	state: string
+	zip: string
+	websiteUrl: string
+	email: string
+	phone: string
+	notes?: string | null
+	logo: string
+}
+
+export interface GolfCourseData {
+	id: number
+	name: string
+	addressText: string
+	city: string
+	state: string
+	zip: string
+	websiteUrl: string
+	email: string
+	phone: string
+	notes: string | null
+	logo: string
+}
+
+export async function listGolfCoursesAction(): Promise<ActionResult<GolfCourseData[]>> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	try {
+		const results = await db
+			.select({
+				id: golfCourse.id,
+				name: golfCourse.name,
+				addressText: golfCourse.addressText,
+				city: golfCourse.city,
+				state: golfCourse.state,
+				zip: golfCourse.zip,
+				websiteUrl: golfCourse.websiteUrl,
+				email: golfCourse.email,
+				phone: golfCourse.phone,
+				notes: golfCourse.notes,
+				logo: golfCourse.logo,
+			})
+			.from(golfCourse)
+			.orderBy(asc(golfCourse.name))
+
+		return { success: true, data: results }
+	} catch (error) {
+		console.error("Failed to list golf courses:", error)
+		return { success: false, error: "Failed to list golf courses" }
+	}
+}
+
+export async function getGolfCourseAction(id: number): Promise<ActionResult<GolfCourseData>> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	try {
+		const results = await db
+			.select({
+				id: golfCourse.id,
+				name: golfCourse.name,
+				addressText: golfCourse.addressText,
+				city: golfCourse.city,
+				state: golfCourse.state,
+				zip: golfCourse.zip,
+				websiteUrl: golfCourse.websiteUrl,
+				email: golfCourse.email,
+				phone: golfCourse.phone,
+				notes: golfCourse.notes,
+				logo: golfCourse.logo,
+			})
+			.from(golfCourse)
+			.where(eq(golfCourse.id, id))
+
+		if (results.length === 0) {
+			return { success: false, error: "Golf course not found" }
+		}
+
+		return { success: true, data: results[0] }
+	} catch (error) {
+		console.error("Failed to get golf course:", error)
+		return { success: false, error: "Failed to get golf course" }
+	}
+}
+
+export async function saveGolfCourseAction(
+	data: GolfCourseInput,
+): Promise<ActionResult<{ id: number }>> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	const name = data.name?.trim()
+
+	if (!name) {
+		return { success: false, error: "Name is required" }
+	}
+
+	try {
+		if (data.id !== undefined) {
+			await db
+				.update(golfCourse)
+				.set({
+					name,
+					addressText: data.addressText,
+					city: data.city,
+					state: data.state,
+					zip: data.zip,
+					websiteUrl: data.websiteUrl,
+					email: data.email,
+					phone: data.phone,
+					notes: data.notes ?? null,
+					logo: data.logo,
+				})
+				.where(eq(golfCourse.id, data.id))
+
+			return { success: true, data: { id: data.id } }
+		} else {
+			const result = await db.insert(golfCourse).values({
+				name,
+				addressText: data.addressText,
+				city: data.city,
+				state: data.state,
+				zip: data.zip,
+				websiteUrl: data.websiteUrl,
+				email: data.email,
+				phone: data.phone,
+				notes: data.notes ?? null,
+				logo: data.logo,
+			})
+
+			return { success: true, data: { id: result[0].insertId } }
+		}
+	} catch (error) {
+		console.error("Failed to save golf course:", error)
+		return { success: false, error: "Failed to save golf course" }
+	}
+}
+
+export async function deleteGolfCourseAction(id: number): Promise<ActionResult> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	try {
+		await db.delete(golfCourse).where(eq(golfCourse.id, id))
+		return { success: true }
+	} catch (error) {
+		console.error("Failed to delete golf course:", error)
+
+		if (error instanceof Error && error.message.includes("foreign key constraint")) {
+			return {
+				success: false,
+				error: "Cannot delete: this golf course is linked to a club or tournament",
+			}
+		}
+
+		return { success: false, error: "Failed to delete golf course" }
+	}
+}

--- a/apps/admin/src/app/(dashboard)/members/golf-courses/golf-course-form.tsx
+++ b/apps/admin/src/app/(dashboard)/members/golf-courses/golf-course-form.tsx
@@ -1,0 +1,268 @@
+"use client"
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+	Button,
+	Card,
+	CardContent,
+	CardHeader,
+	CardTitle,
+	Field,
+	FieldError,
+	FieldLabel,
+	Input,
+	Textarea,
+	toast,
+} from "@mpga/ui"
+import { Trash2 } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { useState } from "react"
+
+import { type GolfCourseData, deleteGolfCourseAction, saveGolfCourseAction } from "./actions"
+
+interface GolfCourseFormProps {
+	golfCourse?: GolfCourseData
+}
+
+export function GolfCourseForm({ golfCourse }: GolfCourseFormProps) {
+	const router = useRouter()
+	const [saving, setSaving] = useState(false)
+	const [deleting, setDeleting] = useState(false)
+	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+
+	const [name, setName] = useState(golfCourse?.name ?? "")
+	const [websiteUrl, setWebsiteUrl] = useState(golfCourse?.websiteUrl ?? "")
+	const [email, setEmail] = useState(golfCourse?.email ?? "")
+	const [phone, setPhone] = useState(golfCourse?.phone ?? "")
+	const [addressText, setAddressText] = useState(golfCourse?.addressText ?? "")
+	const [city, setCity] = useState(golfCourse?.city ?? "")
+	const [state, setState] = useState(golfCourse?.state ?? "")
+	const [zip, setZip] = useState(golfCourse?.zip ?? "")
+	const [logo, setLogo] = useState(golfCourse?.logo ?? "")
+	const [notes, setNotes] = useState(golfCourse?.notes ?? "")
+
+	const handleSave = async (e: React.FormEvent) => {
+		e.preventDefault()
+
+		if (!name.trim()) {
+			setError("Name is required")
+			return
+		}
+
+		setSaving(true)
+		setError(null)
+
+		try {
+			const result = await saveGolfCourseAction({
+				id: golfCourse?.id,
+				name: name.trim(),
+				websiteUrl: websiteUrl.trim(),
+				email: email.trim(),
+				phone: phone.trim(),
+				addressText: addressText.trim(),
+				city: city.trim(),
+				state: state.trim(),
+				zip: zip.trim(),
+				logo: logo.trim(),
+				notes: notes.trim() || null,
+			})
+
+			if (result.success) {
+				toast.success(golfCourse ? "Golf course updated" : "Golf course created")
+				router.push("/members/golf-courses")
+			} else {
+				setError(result.error ?? "Failed to save golf course")
+			}
+		} catch (err) {
+			console.error("Failed to save golf course:", err)
+			setError("Failed to save golf course")
+		} finally {
+			setSaving(false)
+		}
+	}
+
+	const handleCancel = () => {
+		router.push("/members/golf-courses")
+	}
+
+	const handleDelete = async () => {
+		if (!golfCourse?.id) return
+
+		setDeleting(true)
+		setError(null)
+
+		try {
+			const result = await deleteGolfCourseAction(golfCourse.id)
+
+			if (result.success) {
+				toast.success("Golf course deleted")
+				router.push("/members/golf-courses")
+			} else {
+				setDeleteDialogOpen(false)
+				setError(result.error ?? "Failed to delete golf course")
+			}
+		} catch (err) {
+			console.error("Failed to delete golf course:", err)
+			setDeleteDialogOpen(false)
+			setError("Failed to delete golf course")
+		} finally {
+			setDeleting(false)
+		}
+	}
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="font-heading">Golf Course Information</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<form onSubmit={handleSave} className="space-y-4">
+					{/* Row 1: Name */}
+					<Field>
+						<FieldLabel htmlFor="name">
+							Name <span className="text-destructive">*</span>
+						</FieldLabel>
+						<Input id="name" value={name} onChange={(e) => setName(e.target.value)} required />
+					</Field>
+
+					{/* Row 2: Website URL */}
+					<Field>
+						<FieldLabel htmlFor="websiteUrl">Website URL</FieldLabel>
+						<Input
+							id="websiteUrl"
+							value={websiteUrl}
+							onChange={(e) => setWebsiteUrl(e.target.value)}
+						/>
+					</Field>
+
+					{/* Row 3: Email and Phone */}
+					<div className="grid grid-cols-2 gap-4">
+						<Field>
+							<FieldLabel htmlFor="email">Email</FieldLabel>
+							<Input
+								id="email"
+								type="email"
+								value={email}
+								onChange={(e) => setEmail(e.target.value)}
+							/>
+						</Field>
+						<Field>
+							<FieldLabel htmlFor="phone">Phone</FieldLabel>
+							<Input id="phone" value={phone} onChange={(e) => setPhone(e.target.value)} />
+						</Field>
+					</div>
+
+					{/* Row 4: Address */}
+					<Field>
+						<FieldLabel htmlFor="addressText">Address</FieldLabel>
+						<Input
+							id="addressText"
+							value={addressText}
+							onChange={(e) => setAddressText(e.target.value)}
+						/>
+					</Field>
+
+					{/* Row 5: City, State, Zip */}
+					<div className="grid grid-cols-4 gap-4">
+						<Field className="col-span-2">
+							<FieldLabel htmlFor="city">City</FieldLabel>
+							<Input id="city" value={city} onChange={(e) => setCity(e.target.value)} />
+						</Field>
+						<Field>
+							<FieldLabel htmlFor="state">State</FieldLabel>
+							<Input
+								id="state"
+								value={state}
+								onChange={(e) => setState(e.target.value)}
+								maxLength={2}
+							/>
+						</Field>
+						<Field>
+							<FieldLabel htmlFor="zip">Zip</FieldLabel>
+							<Input id="zip" value={zip} onChange={(e) => setZip(e.target.value)} />
+						</Field>
+					</div>
+
+					{/* Row 6: Logo */}
+					<Field>
+						<FieldLabel htmlFor="logo">Logo</FieldLabel>
+						<Input id="logo" value={logo} onChange={(e) => setLogo(e.target.value)} />
+					</Field>
+
+					{/* Row 7: Notes */}
+					<Field>
+						<FieldLabel htmlFor="notes">Notes</FieldLabel>
+						<Textarea
+							id="notes"
+							value={notes}
+							onChange={(e) => setNotes(e.target.value)}
+							rows={4}
+						/>
+					</Field>
+
+					{/* Error message */}
+					{error && <FieldError>{error}</FieldError>}
+
+					{/* Action buttons */}
+					<div className="flex justify-between pt-4">
+						{/* Delete button - only shown when editing */}
+						{golfCourse && (
+							<AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+								<AlertDialogTrigger asChild>
+									<Button type="button" variant="destructive">
+										<Trash2 className="mr-2 h-4 w-4" />
+										Delete
+									</Button>
+								</AlertDialogTrigger>
+								<AlertDialogContent>
+									<AlertDialogHeader>
+										<AlertDialogTitle>Delete Golf Course</AlertDialogTitle>
+										<AlertDialogDescription>
+											Are you sure you want to delete {golfCourse.name}? This action cannot be
+											undone.
+										</AlertDialogDescription>
+									</AlertDialogHeader>
+									<AlertDialogFooter>
+										<AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+										<AlertDialogAction
+											onClick={(e) => {
+												e.preventDefault()
+												handleDelete()
+											}}
+											disabled={deleting}
+											className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+										>
+											{deleting ? "Deleting..." : "Delete"}
+										</AlertDialogAction>
+									</AlertDialogFooter>
+								</AlertDialogContent>
+							</AlertDialog>
+						)}
+
+						{/* Spacer when no delete button */}
+						{!golfCourse && <div />}
+
+						{/* Save/Cancel buttons on the right */}
+						<div className="flex gap-2">
+							<Button type="button" variant="secondaryoutline" onClick={handleCancel}>
+								Cancel
+							</Button>
+							<Button type="submit" variant="secondary" disabled={saving}>
+								{saving ? "Saving..." : "Save"}
+							</Button>
+						</div>
+					</div>
+				</form>
+			</CardContent>
+		</Card>
+	)
+}

--- a/apps/admin/src/app/(dashboard)/members/golf-courses/new/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/golf-courses/new/page.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { H1 } from "@mpga/ui"
+
+import { GolfCourseForm } from "../golf-course-form"
+
+export default function NewGolfCoursePage() {
+	return (
+		<div className="mx-auto max-w-4xl">
+			<H1 variant="secondary" className="mb-6">
+				New Golf Course
+			</H1>
+			<GolfCourseForm />
+		</div>
+	)
+}

--- a/apps/admin/src/app/(dashboard)/members/golf-courses/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/golf-courses/page.tsx
@@ -104,6 +104,7 @@ export default function GolfCoursesPage() {
 	const router = useRouter()
 	const [courses, setCourses] = useState<GolfCourseData[]>([])
 	const [loading, setLoading] = useState(true)
+	const [error, setError] = useState<string | null>(null)
 	const [globalFilter, setGlobalFilter] = useState("")
 	const [sorting, setSorting] = useState<SortingState>([{ id: "name", desc: false }])
 	const [pagination, setPagination] = useState<PaginationState>({
@@ -118,9 +119,12 @@ export default function GolfCoursesPage() {
 				const result = await listGolfCoursesAction()
 				if (result.success && result.data) {
 					setCourses(result.data)
+				} else {
+					setError(result.error ?? "Failed to load golf courses")
 				}
 			} catch (err) {
 				console.error("Failed to fetch golf courses:", err)
+				setError("Failed to load golf courses")
 			} finally {
 				setLoading(false)
 			}
@@ -172,6 +176,8 @@ export default function GolfCoursesPage() {
 
 			{loading ? (
 				<EmptyState message="Loading golf courses..." />
+			) : error ? (
+				<EmptyState message={error} />
 			) : courses.length === 0 ? (
 				<EmptyState message="No golf courses found" />
 			) : (

--- a/apps/admin/src/app/(dashboard)/members/golf-courses/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/golf-courses/page.tsx
@@ -1,14 +1,266 @@
-import { H1 } from "@mpga/ui"
+"use client"
+
+import {
+	Button,
+	Card,
+	EmptyState,
+	H1,
+	PageSizeSelect,
+	Pagination,
+	SearchInput,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@mpga/ui"
+import {
+	type Column,
+	type ColumnDef,
+	type FilterFn,
+	type PaginationState,
+	type SortingFn,
+	type SortingState,
+	flexRender,
+	getCoreRowModel,
+	getFilteredRowModel,
+	getPaginationRowModel,
+	getSortedRowModel,
+	useReactTable,
+} from "@tanstack/react-table"
+import { ChevronDown, ChevronUp, ChevronsUpDown } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { useEffect, useState } from "react"
+
+import { type GolfCourseData, listGolfCoursesAction } from "./actions"
+
+const formatCityState = (city: string, state: string) => {
+	if (city && state) return `${city}, ${state}`
+	if (city) return city
+	if (state) return state
+	return "-"
+}
+
+const cityStateSortingFn: SortingFn<GolfCourseData> = (rowA, rowB) => {
+	const a = rowA.original
+	const b = rowB.original
+	const cityCompare = a.city.localeCompare(b.city)
+	if (cityCompare !== 0) return cityCompare
+	return a.state.localeCompare(b.state)
+}
+
+const golfCourseGlobalFilterFn: FilterFn<GolfCourseData> = (row, _columnId, filterValue) => {
+	const term = (filterValue as string).toLowerCase()
+	if (!term) return true
+
+	const course = row.original
+	const name = course.name.toLowerCase()
+	const email = course.email.toLowerCase()
+	const phone = course.phone.toLowerCase()
+	const city = course.city.toLowerCase()
+
+	return name.includes(term) || email.includes(term) || phone.includes(term) || city.includes(term)
+}
+
+const columns: ColumnDef<GolfCourseData>[] = [
+	{
+		accessorKey: "name",
+		header: "Name",
+		cell: ({ getValue }) => <span className="font-medium">{getValue<string>()}</span>,
+	},
+	{
+		id: "cityState",
+		header: "City/State",
+		accessorFn: (row) => formatCityState(row.city, row.state),
+		sortingFn: cityStateSortingFn,
+	},
+	{
+		accessorKey: "phone",
+		header: "Phone",
+		enableSorting: false,
+		cell: ({ getValue }) => getValue<string>() || "-",
+	},
+	{
+		accessorKey: "email",
+		header: "Email",
+		cell: ({ getValue }) => getValue<string>() || "-",
+	},
+]
+
+function SortIcon({ column }: { column: Column<GolfCourseData> }) {
+	const sorted = column.getIsSorted()
+	if (!sorted) {
+		return <ChevronsUpDown className="ml-1 inline h-4 w-4 opacity-50" />
+	}
+	return sorted === "asc" ? (
+		<ChevronUp className="ml-1 inline h-4 w-4" />
+	) : (
+		<ChevronDown className="ml-1 inline h-4 w-4" />
+	)
+}
 
 export default function GolfCoursesPage() {
+	const router = useRouter()
+	const [courses, setCourses] = useState<GolfCourseData[]>([])
+	const [loading, setLoading] = useState(true)
+	const [globalFilter, setGlobalFilter] = useState("")
+	const [sorting, setSorting] = useState<SortingState>([{ id: "name", desc: false }])
+	const [pagination, setPagination] = useState<PaginationState>({
+		pageIndex: 0,
+		pageSize: 25,
+	})
+	const [pageSizeOption, setPageSizeOption] = useState<string>("25")
+
+	useEffect(() => {
+		async function fetchCourses() {
+			try {
+				const result = await listGolfCoursesAction()
+				if (result.success && result.data) {
+					setCourses(result.data)
+				}
+			} catch (err) {
+				console.error("Failed to fetch golf courses:", err)
+			} finally {
+				setLoading(false)
+			}
+		}
+
+		fetchCourses()
+	}, [])
+
+	const table = useReactTable({
+		data: courses,
+		columns,
+		state: {
+			sorting,
+			globalFilter,
+			pagination,
+		},
+		onSortingChange: setSorting,
+		onGlobalFilterChange: setGlobalFilter,
+		onPaginationChange: setPagination,
+		globalFilterFn: golfCourseGlobalFilterFn,
+		autoResetPageIndex: true,
+		getCoreRowModel: getCoreRowModel(),
+		getFilteredRowModel: getFilteredRowModel(),
+		getSortedRowModel: getSortedRowModel(),
+		getPaginationRowModel: getPaginationRowModel(),
+	})
+
+	const handlePageSizeChange = (value: string) => {
+		setPageSizeOption(value)
+		if (value === "all") {
+			table.setPageSize(courses.length || 1)
+		} else {
+			table.setPageSize(Number(value))
+		}
+		table.setPageIndex(0)
+	}
+
+	const filteredCount = table.getFilteredRowModel().rows.length
+	const showPagination = pageSizeOption !== "all" && table.getPageCount() > 1
+
 	return (
 		<div className="mx-auto max-w-6xl">
-			<H1 variant="secondary" className="mb-6">
-				Golf Courses
-			</H1>
-			<div className="rounded-lg border bg-white p-6">
-				<p className="text-gray-500">Golf Courses management coming soon.</p>
+			<div className="mb-6 flex items-center justify-between">
+				<H1 variant="secondary">Golf Courses</H1>
+				<Button variant="secondary" onClick={() => router.push("/members/golf-courses/new")}>
+					Add Golf Course
+				</Button>
 			</div>
+
+			{loading ? (
+				<EmptyState message="Loading golf courses..." />
+			) : courses.length === 0 ? (
+				<EmptyState message="No golf courses found" />
+			) : (
+				<div className="space-y-4">
+					{/* Controls row */}
+					<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+						<SearchInput
+							variant="secondary"
+							placeholder="Search golf courses..."
+							value={globalFilter}
+							onChange={(e) => setGlobalFilter(e.target.value)}
+						/>
+						<div className="flex items-center gap-4">
+							<PageSizeSelect
+								value={pageSizeOption}
+								onChange={handlePageSizeChange}
+								options={[10, 25, 50, 100, "all"]}
+							/>
+							<p className="text-sm text-gray-600">
+								{filteredCount} {filteredCount === 1 ? "course" : "courses"}
+								{globalFilter && ` (filtered)`}
+							</p>
+						</div>
+					</div>
+
+					{filteredCount === 0 ? (
+						<EmptyState message="No golf courses match your search" />
+					) : (
+						<>
+							{/* Table */}
+							<Card className="overflow-x-auto p-0">
+								<Table className="min-w-full divide-y divide-gray-200">
+									<TableHeader className="bg-secondary-50">
+										<TableRow className="hover:bg-secondary-50">
+											{table.getHeaderGroups().map((headerGroup) =>
+												headerGroup.headers.map((header) => (
+													<TableHead
+														key={header.id}
+														className={`px-4 py-3 text-xs font-semibold uppercase tracking-wider text-secondary-900${
+															header.column.getCanSort()
+																? " cursor-pointer transition-colors hover:bg-secondary-100"
+																: ""
+														}`}
+														onClick={header.column.getToggleSortingHandler()}
+													>
+														{header.column.getCanSort() ? (
+															<span className="flex items-center gap-1">
+																{flexRender(header.column.columnDef.header, header.getContext())}
+																<SortIcon column={header.column} />
+															</span>
+														) : (
+															flexRender(header.column.columnDef.header, header.getContext())
+														)}
+													</TableHead>
+												)),
+											)}
+										</TableRow>
+									</TableHeader>
+									<TableBody className="divide-y divide-gray-100 bg-white">
+										{table.getRowModel().rows.map((row) => (
+											<TableRow
+												key={row.original.id}
+												className="cursor-pointer hover:bg-gray-50"
+												onClick={() => router.push(`/members/golf-courses/${row.original.id}`)}
+											>
+												{row.getVisibleCells().map((cell) => (
+													<TableCell key={cell.id} className="px-4 py-3 text-sm">
+														{flexRender(cell.column.columnDef.cell, cell.getContext())}
+													</TableCell>
+												))}
+											</TableRow>
+										))}
+									</TableBody>
+								</Table>
+							</Card>
+
+							{/* Pagination */}
+							{showPagination && (
+								<Pagination
+									currentPage={table.getState().pagination.pageIndex + 1}
+									totalPages={table.getPageCount()}
+									onPreviousPage={() => table.previousPage()}
+									onNextPage={() => table.nextPage()}
+								/>
+							)}
+						</>
+					)}
+				</div>
+			)}
 		</div>
 	)
 }

--- a/apps/admin/src/app/(dashboard)/members/landing/actions.ts
+++ b/apps/admin/src/app/(dashboard)/members/landing/actions.ts
@@ -8,8 +8,8 @@ import {
 	saveContentAction as saveContent,
 } from "@/lib/content-actions"
 
-export async function getContentAction(contentType: string): Promise<ActionResult<ContentData>> {
-	return getContent(contentType)
+export async function getContentAction(): Promise<ActionResult<ContentData>> {
+	return getContent("C")
 }
 
 export async function saveContentAction(data: {
@@ -18,5 +18,5 @@ export async function saveContentAction(data: {
 	title: string
 	contentText: string
 }): Promise<ActionResult<{ id: number }>> {
-	return saveContent(data, "/tournaments")
+	return saveContent(data, "/members")
 }

--- a/apps/admin/src/app/(dashboard)/members/landing/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/landing/page.tsx
@@ -1,14 +1,45 @@
 import { H1 } from "@mpga/ui"
 
+import { ContentEditor } from "@/components/content-editor"
+
+import { getContentAction, saveContentAction } from "./actions"
+
+async function loadLandingContent() {
+	"use server"
+	const result = await getContentAction()
+	if (!result.success || !result.data) return null
+	return {
+		title: result.data.title,
+		content: result.data.contentText,
+		id: result.data.id,
+	}
+}
+
+async function saveLandingContent(data: { id?: number; title: string; content: string }) {
+	"use server"
+	return saveContentAction({
+		id: data.id,
+		contentType: "C",
+		title: data.title,
+		contentText: data.content,
+	})
+}
+
 export default function MembersLandingPagePage() {
 	return (
 		<div className="mx-auto max-w-6xl">
-			<H1 variant="secondary" className="mb-6">
+			<H1 variant="secondary" className="mb-2">
 				Members Landing Page
 			</H1>
-			<div className="rounded-lg border bg-white p-6">
-				<p className="text-gray-500">Members Landing Page management coming soon.</p>
-			</div>
+			<p className="mb-6 text-muted-foreground">
+				This content is displayed at the top of the Members page on the public site, above the clubs
+				membership table.
+			</p>
+			<ContentEditor
+				loadContent={loadLandingContent}
+				saveContent={saveLandingContent}
+				preview={{ heading: "h1" }}
+			/>
 		</div>
 	)
 }

--- a/apps/admin/src/app/globals.css
+++ b/apps/admin/src/app/globals.css
@@ -37,6 +37,32 @@
   }
 }
 
+/* Markdown editor scrollbar */
+.markdown-editor-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.markdown-editor-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.markdown-editor-scroll::-webkit-scrollbar-thumb {
+  background-color: var(--color-secondary-200);
+  border-radius: 3px;
+}
+
+.markdown-editor-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-secondary-400);
+}
+
+/* Firefox */
+@supports not selector(::-webkit-scrollbar) {
+  .markdown-editor-scroll {
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-secondary-200) transparent;
+  }
+}
+
 /* Tiptap WYSIWYG editor styles */
 .tiptap-editor {
   h1, h2, h3, h4, h5, h6 {

--- a/apps/admin/src/components/content-editor.tsx
+++ b/apps/admin/src/components/content-editor.tsx
@@ -1,61 +1,31 @@
 "use client"
 
+import type { ActionResult } from "@mpga/types"
 import {
 	Button,
 	Card,
 	CardContent,
 	CardHeader,
 	CardTitle,
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
+	ContentCard,
 	FieldLabel,
 	Input,
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetHeader,
+	SheetTitle,
 	Skeleton,
-	Textarea,
 	toast,
-	Tooltip,
-	TooltipContent,
-	TooltipProvider,
-	TooltipTrigger,
 } from "@mpga/ui"
-import type { ActionResult } from "@mpga/types"
-import Link from "@tiptap/extension-link"
-import { EditorContent, useEditor } from "@tiptap/react"
-import StarterKit from "@tiptap/starter-kit"
-import {
-	AlertTriangle,
-	ArrowLeft,
-	Bold,
-	ChevronDown,
-	Code,
-	Eye,
-	Heading2,
-	Heading3,
-	Heading4,
-	Highlighter,
-	Info,
-	Italic,
-	Lightbulb,
-	Link as LinkIcon,
-	List,
-	ListOrdered,
-	Loader2,
-	Minus,
-	RemoveFormatting,
-	ShieldAlert,
-	TextQuote,
-} from "lucide-react"
+import { ArrowLeft, Eye, Loader2, Monitor, Smartphone } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useCallback, useEffect, useRef, useState } from "react"
-import { Markdown } from "tiptap-markdown"
 
-import { Admonition, type AdmonitionType } from "@/lib/tiptap/admonition"
-import { HighlightWithMarkdown } from "@/lib/tiptap/highlight"
+import { MarkdownEditor } from "./markdown-editor"
 
 interface ContentEditorProps {
-	backHref: string
+	backHref?: string
 	loadContent: () => Promise<{ title: string; content: string; id?: number } | null>
 	saveContent: (data: {
 		id?: number
@@ -63,6 +33,10 @@ interface ContentEditorProps {
 		content: string
 	}) => Promise<ActionResult<{ id: number }>>
 	showTitle?: boolean
+	preview?: {
+		heading: "h1" | "h2" | "h3" | "h4"
+		variant?: "primary" | "secondary"
+	}
 }
 
 export function ContentEditor({
@@ -70,36 +44,17 @@ export function ContentEditor({
 	loadContent,
 	saveContent,
 	showTitle = true,
+	preview,
 }: ContentEditorProps) {
 	const router = useRouter()
 	const [loading, setLoading] = useState(true)
 	const [saving, setSaving] = useState(false)
 	const [title, setTitle] = useState("")
 	const [contentId, setContentId] = useState<number | undefined>()
-	const [mode, setMode] = useState<"wysiwyg" | "markdown">("wysiwyg")
-	const [markdownText, setMarkdownText] = useState("")
+	const [markdownContent, setMarkdownContent] = useState("")
+	const [previewOpen, setPreviewOpen] = useState(false)
+	const [previewMobile, setPreviewMobile] = useState(false)
 	const savedState = useRef({ title: "", content: "" })
-
-	const editor = useEditor({
-		extensions: [
-			StarterKit,
-			Markdown,
-			Link.configure({
-				openOnClick: false,
-				HTMLAttributes: {
-					class: "text-primary underline",
-				},
-			}),
-			HighlightWithMarkdown,
-			Admonition,
-		],
-		immediatelyRender: false,
-		editorProps: {
-			attributes: {
-				class: "prose min-h-[400px] p-4 focus:outline-none",
-			},
-		},
-	})
 
 	const loaded = useRef(false)
 
@@ -111,38 +66,17 @@ export function ContentEditor({
 			if (data) {
 				setTitle(data.title)
 				setContentId(data.id)
+				setMarkdownContent(data.content)
 				savedState.current = { title: data.title, content: data.content }
-				if (editor) {
-					editor.commands.setContent(data.content)
-				}
 			}
 			setLoading(false)
 		}
-		if (editor) {
-			load()
-		}
-	}, [editor, loadContent])
-
-	const switchToMarkdown = useCallback(() => {
-		if (!editor) return
-		const md = editor.storage.markdown.getMarkdown() as string
-		setMarkdownText(md)
-		setMode("markdown")
-	}, [editor])
-
-	const switchToWysiwyg = useCallback(() => {
-		if (!editor) return
-		editor.commands.setContent(markdownText)
-		setMode("wysiwyg")
-	}, [editor, markdownText])
+		load()
+	}, [loadContent])
 
 	const handleSave = useCallback(async () => {
-		if (!editor) return
-
 		setSaving(true)
 		try {
-			const markdownContent =
-				mode === "markdown" ? markdownText : (editor.storage.markdown.getMarkdown() as string)
 			const result = await saveContent({
 				id: contentId,
 				title: title.trim(),
@@ -163,18 +97,16 @@ export function ContentEditor({
 		} finally {
 			setSaving(false)
 		}
-	}, [editor, contentId, title, mode, markdownText, saveContent])
+	}, [contentId, title, markdownContent, saveContent])
 
 	const isDirty = useCallback(() => {
-		if (!editor) return false
-		const currentContent =
-			mode === "markdown" ? markdownText : (editor.storage.markdown.getMarkdown() as string)
 		return (
-			title.trim() !== savedState.current.title || currentContent !== savedState.current.content
+			title.trim() !== savedState.current.title || markdownContent !== savedState.current.content
 		)
-	}, [editor, title, mode, markdownText])
+	}, [title, markdownContent])
 
 	const handleBack = useCallback(() => {
+		if (!backHref) return
 		if (isDirty()) {
 			if (!window.confirm("You have unsaved changes. Are you sure you want to leave?")) {
 				return
@@ -182,22 +114,6 @@ export function ContentEditor({
 		}
 		router.push(backHref)
 	}, [isDirty, router, backHref])
-
-	const setLink = useCallback(() => {
-		if (!editor) return
-
-		const previousUrl = editor.getAttributes("link").href as string
-		const url = window.prompt("URL", previousUrl)
-
-		if (url === null) return
-
-		if (url === "") {
-			editor.chain().focus().extendMarkRange("link").unsetLink().run()
-			return
-		}
-
-		editor.chain().focus().extendMarkRange("link").setLink({ href: url }).run()
-	}, [editor])
 
 	if (loading) {
 		return (
@@ -207,275 +123,120 @@ export function ContentEditor({
 				</CardHeader>
 				<CardContent className="space-y-4">
 					<Skeleton className="h-10 w-full" />
-					<Skeleton className="h-[400px] w-full" />
+					<Skeleton className="h-100 w-full" />
 				</CardContent>
 			</Card>
 		)
 	}
 
 	return (
-		<Card>
-			<div className="sticky top-0 z-10 rounded-t-lg bg-card">
-				<div className="flex pb-2">
-					<div className="w-[70%]">
-						<CardHeader>
-							<CardTitle>
-								{showTitle ? (
-									<>
-										<FieldLabel htmlFor="content-title">Title (h2)</FieldLabel>
-										<Input
-											id="content-title"
-											value={title}
-											onChange={(e) => setTitle(e.target.value)}
-											placeholder="Title"
-											className="text-lg font-semibold"
-										/>
-									</>
-								) : (
-									<span className="text-lg font-semibold">{title}</span>
-								)}
-							</CardTitle>
-						</CardHeader>
-					</div>
-					<div className="flex w-[30%] items-center justify-end gap-2 pr-6">
-						<Button variant="secondaryoutline" onClick={handleBack} disabled={saving}>
-							<ArrowLeft className="h-4 w-4" />
-							Back
-						</Button>
-						<Button
-							variant="secondary"
-							onClick={handleSave}
-							disabled={saving || (showTitle && !title.trim())}
-						>
-							{saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-							Save
-						</Button>
+		<>
+			<Card>
+				<div className="sticky top-0 z-10 rounded-t-lg bg-card">
+					<div className="flex pb-2">
+						<div className="w-[70%]">
+							<CardHeader>
+								<CardTitle>
+									{showTitle ? (
+										<>
+											<FieldLabel htmlFor="content-title">Title (h2)</FieldLabel>
+											<Input
+												id="content-title"
+												value={title}
+												onChange={(e) => setTitle(e.target.value)}
+												placeholder="Title"
+												className="text-lg font-semibold"
+											/>
+										</>
+									) : (
+										<span className="text-lg font-semibold">{title}</span>
+									)}
+								</CardTitle>
+							</CardHeader>
+						</div>
+						<div className="flex w-[30%] items-center justify-end gap-2 pr-6">
+							{backHref && (
+								<Button variant="secondaryoutline" onClick={handleBack} disabled={saving}>
+									<ArrowLeft className="h-4 w-4" />
+									Back
+								</Button>
+							)}
+							{preview && (
+								<Button variant="secondaryoutline" onClick={() => setPreviewOpen(true)}>
+									<Eye className="h-4 w-4" />
+									Preview
+								</Button>
+							)}
+							<Button
+								variant="secondary"
+								onClick={handleSave}
+								disabled={saving || (showTitle && !title.trim())}
+							>
+								{saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+								Save
+							</Button>
+						</div>
 					</div>
 				</div>
-				{editor && (
-					<div className="px-6 pb-4">
-						<TooltipProvider delayDuration={2000}>
-							<div className="flex items-center gap-1 rounded-md border-2 border-secondary-500 bg-muted/50 p-1">
-								{mode === "wysiwyg" && (
-									<>
-										<ToolbarButton
-											onClick={() => editor.chain().focus().toggleBold().run()}
-											active={editor.isActive("bold")}
-											title="Bold"
-										>
-											<Bold className="h-4 w-4" />
-										</ToolbarButton>
-										<ToolbarButton
-											onClick={() => editor.chain().focus().toggleItalic().run()}
-											active={editor.isActive("italic")}
-											title="Italic"
-										>
-											<Italic className="h-4 w-4" />
-										</ToolbarButton>
-										<ToolbarButton
-											onClick={() => editor.chain().focus().toggleHighlight().run()}
-											active={editor.isActive("highlight")}
-											title="Highlight"
-										>
-											<Highlighter className="h-4 w-4" />
-										</ToolbarButton>
-										<ToolbarSeparator />
-										<ToolbarButton
-											onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
-											active={editor.isActive("heading", { level: 2 })}
-											title="Heading 2"
-										>
-											<Heading2 className="h-4 w-4" />
-										</ToolbarButton>
-										<ToolbarButton
-											onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
-											active={editor.isActive("heading", { level: 3 })}
-											title="Heading 3"
-										>
-											<Heading3 className="h-4 w-4" />
-										</ToolbarButton>
-										<ToolbarButton
-											onClick={() => editor.chain().focus().toggleHeading({ level: 4 }).run()}
-											active={editor.isActive("heading", { level: 4 })}
-											title="Heading 4"
-										>
-											<Heading4 className="h-4 w-4" />
-										</ToolbarButton>
-										<ToolbarSeparator />
-										<ToolbarButton
-											onClick={() => editor.chain().focus().toggleBulletList().run()}
-											active={editor.isActive("bulletList")}
-											title="Bullet list"
-										>
-											<List className="h-4 w-4" />
-										</ToolbarButton>
-										<ToolbarButton
-											onClick={() => editor.chain().focus().toggleOrderedList().run()}
-											active={editor.isActive("orderedList")}
-											title="Ordered list"
-										>
-											<ListOrdered className="h-4 w-4" />
-										</ToolbarButton>
-										<ToolbarSeparator />
-										<ToolbarButton
-											onClick={() => editor.chain().focus().toggleBlockquote().run()}
-											active={editor.isActive("blockquote")}
-											title="Block quote"
-										>
-											<TextQuote className="h-4 w-4" />
-										</ToolbarButton>
-										<AdmonitionDropdown
-											onSelect={(type) => editor.chain().focus().toggleAdmonition({ type }).run()}
-											active={editor.isActive("admonition")}
-										/>
-										<ToolbarSeparator />
-										<ToolbarButton onClick={setLink} active={editor.isActive("link")} title="Link">
-											<LinkIcon className="h-4 w-4" />
-										</ToolbarButton>
-										<ToolbarButton
-											onClick={() => editor.chain().focus().setHorizontalRule().run()}
-											title="Horizontal rule"
-										>
-											<Minus className="h-4 w-4" />
-										</ToolbarButton>
-										<ToolbarSeparator />
-										<ToolbarButton
-											onClick={() => editor.chain().focus().clearNodes().unsetAllMarks().run()}
-											title="Clear formatting"
-										>
-											<RemoveFormatting className="h-4 w-4" />
-										</ToolbarButton>
-									</>
-								)}
-								<div className="ml-auto flex">
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<button
-												type="button"
-												onClick={mode === "markdown" ? switchToWysiwyg : undefined}
-												className={`cursor-pointer rounded-l-md p-2 transition-all duration-150 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
-													mode === "wysiwyg"
-														? "bg-secondary-500 text-white"
-														: "text-muted-foreground hover:bg-secondary-100 hover:text-secondary-700"
-												}`}
-											>
-												<Eye className="h-4 w-4" />
-											</button>
-										</TooltipTrigger>
-										<TooltipContent>WYSIWYG</TooltipContent>
-									</Tooltip>
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<button
-												type="button"
-												onClick={mode === "wysiwyg" ? switchToMarkdown : undefined}
-												className={`cursor-pointer rounded-r-md p-2 transition-all duration-150 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
-													mode === "markdown"
-														? "bg-secondary-500 text-white"
-														: "text-muted-foreground hover:bg-secondary-100 hover:text-secondary-700"
-												}`}
-											>
-												<Code className="h-4 w-4" />
-											</button>
-										</TooltipTrigger>
-										<TooltipContent>Markdown</TooltipContent>
-									</Tooltip>
+				<CardContent>
+					<MarkdownEditor value={markdownContent} onChange={setMarkdownContent} />
+				</CardContent>
+			</Card>
+
+			{preview && (
+				<Sheet open={previewOpen} onOpenChange={setPreviewOpen}>
+					<SheetContent className="overflow-y-auto sm:max-w-2xl">
+						<SheetHeader>
+							<SheetTitle>Preview</SheetTitle>
+							<SheetDescription>
+								Preview how this content appears on the public site.
+							</SheetDescription>
+							<div className="flex justify-center">
+								<div className="inline-flex rounded-md border">
+									<button
+										type="button"
+										onClick={() => setPreviewMobile(false)}
+										className={`flex items-center gap-1.5 rounded-l-md px-3 py-1.5 text-sm transition-all duration-150 ${
+											!previewMobile
+												? "bg-secondary-500 text-white"
+												: "text-muted-foreground hover:bg-secondary-100 hover:text-secondary-700"
+										}`}
+									>
+										<Monitor className="h-4 w-4" />
+										Desktop
+									</button>
+									<button
+										type="button"
+										onClick={() => setPreviewMobile(true)}
+										className={`flex items-center gap-1.5 rounded-r-md px-3 py-1.5 text-sm transition-all duration-150 ${
+											previewMobile
+												? "bg-secondary-500 text-white"
+												: "text-muted-foreground hover:bg-secondary-100 hover:text-secondary-700"
+										}`}
+									>
+										<Smartphone className="h-4 w-4" />
+										Mobile
+									</button>
 								</div>
 							</div>
-						</TooltipProvider>
-					</div>
-				)}
-			</div>
-			<CardContent>
-				{mode === "wysiwyg" ? (
-					<div className="rounded-md border border-gray-300">
-						<EditorContent editor={editor} />
-					</div>
-				) : (
-					<Textarea
-						value={markdownText}
-						onChange={(e) => setMarkdownText(e.target.value)}
-						className="min-h-[400px] resize-none p-4 font-mono text-sm"
-					/>
-				)}
-			</CardContent>
-		</Card>
-	)
-}
-
-function ToolbarButton({
-	onClick,
-	active,
-	title,
-	children,
-}: {
-	onClick: () => void
-	active?: boolean
-	title: string
-	children: React.ReactNode
-}) {
-	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<button
-					type="button"
-					onClick={onClick}
-					className={`cursor-pointer rounded p-2 transition-all duration-150 hover:bg-secondary-100 hover:text-secondary-700 active:scale-90 active:bg-secondary-200 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
-						active ? "bg-muted text-primary" : "text-muted-foreground"
-					}`}
-				>
-					{children}
-				</button>
-			</TooltipTrigger>
-			<TooltipContent>{title}</TooltipContent>
-		</Tooltip>
-	)
-}
-
-function ToolbarSeparator() {
-	return <div className="mx-1 w-px self-stretch bg-border" />
-}
-
-const admonitionItems: { type: AdmonitionType; label: string; icon: React.ReactNode }[] = [
-	{ type: "note", label: "Note", icon: <Info className="h-4 w-4 text-blue-500" /> },
-	{ type: "tip", label: "Tip", icon: <Lightbulb className="h-4 w-4 text-green-500" /> },
-	{ type: "warning", label: "Warning", icon: <AlertTriangle className="h-4 w-4 text-amber-500" /> },
-	{ type: "danger", label: "Danger", icon: <ShieldAlert className="h-4 w-4 text-red-500" /> },
-]
-
-function AdmonitionDropdown({
-	onSelect,
-	active,
-}: {
-	onSelect: (type: AdmonitionType) => void
-	active: boolean
-}) {
-	return (
-		<DropdownMenu>
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<DropdownMenuTrigger asChild>
-						<button
-							type="button"
-							className={`flex cursor-pointer items-center gap-0.5 rounded p-2 transition-all duration-150 hover:bg-secondary-100 hover:text-secondary-700 active:scale-90 active:bg-secondary-200 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
-								active ? "bg-muted text-primary" : "text-muted-foreground"
-							}`}
+						</SheetHeader>
+						<div
+							className={
+								previewMobile
+									? "mx-auto mt-4 w-100 origin-top scale-[0.85] rounded-2xl border-4 border-gray-300"
+									: "mt-4"
+							}
 						>
-							<Info className="h-4 w-4" />
-							<ChevronDown className="h-3 w-3" />
-						</button>
-					</DropdownMenuTrigger>
-				</TooltipTrigger>
-				<TooltipContent>Callout block</TooltipContent>
-			</Tooltip>
-			<DropdownMenuContent align="start">
-				{admonitionItems.map((item) => (
-					<DropdownMenuItem key={item.type} onClick={() => onSelect(item.type)}>
-						{item.icon}
-						<span className="ml-2">{item.label}</span>
-					</DropdownMenuItem>
-				))}
-			</DropdownMenuContent>
-		</DropdownMenu>
+							<ContentCard
+								heading={preview.heading}
+								variant={preview.variant}
+								title={title}
+								content={markdownContent}
+							/>
+						</div>
+					</SheetContent>
+				</Sheet>
+			)}
+		</>
 	)
 }

--- a/apps/admin/src/components/markdown-editor.tsx
+++ b/apps/admin/src/components/markdown-editor.tsx
@@ -1,0 +1,410 @@
+"use client"
+
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+	Textarea,
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@mpga/ui"
+import Link from "@tiptap/extension-link"
+import { EditorContent, useEditor } from "@tiptap/react"
+import StarterKit from "@tiptap/starter-kit"
+import {
+	AlertTriangle,
+	Bold,
+	ChevronDown,
+	Code,
+	Eye,
+	Heading2,
+	Heading3,
+	Heading4,
+	Highlighter,
+	Info,
+	Italic,
+	Lightbulb,
+	Link as LinkIcon,
+	List,
+	ListOrdered,
+	Minus,
+	RemoveFormatting,
+	ShieldAlert,
+	TextQuote,
+} from "lucide-react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { Markdown } from "tiptap-markdown"
+
+import { Admonition, type AdmonitionType } from "@/lib/tiptap/admonition"
+import { HighlightWithMarkdown } from "@/lib/tiptap/highlight"
+
+interface MarkdownEditorProps {
+	value: string
+	onChange: (value: string) => void
+	minHeight?: string
+	maxHeight?: string
+	className?: string
+}
+
+export function MarkdownEditor({
+	value,
+	onChange,
+	minHeight = "400px",
+	maxHeight,
+	className,
+}: MarkdownEditorProps) {
+	const [mode, setMode] = useState<"wysiwyg" | "markdown">("wysiwyg")
+	const [markdownText, setMarkdownText] = useState("")
+	const lastEmittedRef = useRef(value)
+	const textareaRef = useRef<HTMLTextAreaElement>(null)
+	const contentRef = useRef<HTMLDivElement>(null)
+	const [measuredMaxHeight, setMeasuredMaxHeight] = useState<string | undefined>()
+
+	// Dynamically measure available viewport space when no explicit maxHeight is provided
+	useEffect(() => {
+		if (maxHeight) return
+
+		const updateMaxHeight = () => {
+			const el = contentRef.current
+			if (!el) return
+			const top = el.getBoundingClientRect().top
+			const available = window.innerHeight - top - 24
+			setMeasuredMaxHeight(`${Math.max(200, available)}px`)
+		}
+
+		requestAnimationFrame(updateMaxHeight)
+		window.addEventListener("resize", updateMaxHeight)
+		return () => window.removeEventListener("resize", updateMaxHeight)
+	}, [maxHeight, mode])
+
+	const effectiveMaxHeight = maxHeight ?? measuredMaxHeight
+
+	const autoResizeTextarea = useCallback(() => {
+		const textarea = textareaRef.current
+		if (!textarea) return
+		textarea.style.height = "auto"
+		textarea.style.height = `${textarea.scrollHeight}px`
+	}, [])
+
+	const editor = useEditor({
+		extensions: [
+			StarterKit,
+			Markdown,
+			Link.configure({
+				openOnClick: false,
+				HTMLAttributes: {
+					class: "text-primary underline",
+				},
+			}),
+			HighlightWithMarkdown,
+			Admonition,
+		],
+		immediatelyRender: false,
+		editorProps: {
+			attributes: {
+				class: `prose tiptap-editor p-4 focus:outline-none`,
+				style: `min-height: ${minHeight}`,
+			},
+		},
+		onUpdate: ({ editor: ed }) => {
+			const md = ed.storage.markdown.getMarkdown() as string
+			lastEmittedRef.current = md
+			onChange(md)
+		},
+	})
+
+	// Set initial content once the editor is ready
+	const initialized = useRef(false)
+	useEffect(() => {
+		if (editor && !initialized.current) {
+			initialized.current = true
+			editor.commands.setContent(value)
+			lastEmittedRef.current = value
+		}
+	}, [editor, value])
+
+	// Sync external value changes (e.g. when parent resets value)
+	useEffect(() => {
+		if (!editor || !initialized.current) return
+		if (value !== lastEmittedRef.current) {
+			lastEmittedRef.current = value
+			editor.commands.setContent(value)
+		}
+	}, [editor, value])
+
+	const switchToMarkdown = useCallback(() => {
+		if (!editor) return
+		const md = editor.storage.markdown.getMarkdown() as string
+		setMarkdownText(md)
+		setMode("markdown")
+		requestAnimationFrame(autoResizeTextarea)
+	}, [editor, autoResizeTextarea])
+
+	const switchToWysiwyg = useCallback(() => {
+		if (!editor) return
+		editor.commands.setContent(markdownText)
+		setMode("wysiwyg")
+	}, [editor, markdownText])
+
+	const handleMarkdownTextChange = useCallback(
+		(text: string) => {
+			setMarkdownText(text)
+			lastEmittedRef.current = text
+			onChange(text)
+		},
+		[onChange],
+	)
+
+	const setLink = useCallback(() => {
+		if (!editor) return
+
+		const previousUrl = editor.getAttributes("link").href as string
+		const url = window.prompt("URL", previousUrl)
+
+		if (url === null) return
+
+		if (url === "") {
+			editor.chain().focus().extendMarkRange("link").unsetLink().run()
+			return
+		}
+
+		editor.chain().focus().extendMarkRange("link").setLink({ href: url }).run()
+	}, [editor])
+
+	if (!editor) return null
+
+	return (
+		<div className={className}>
+			<TooltipProvider delayDuration={1000}>
+				<div className="flex items-center gap-1 rounded-t-md border border-gray-300 bg-secondary-50 p-1">
+					{mode === "wysiwyg" && (
+						<>
+							<ToolbarButton
+								onClick={() => editor.chain().focus().toggleBold().run()}
+								active={editor.isActive("bold")}
+								title="Bold"
+							>
+								<Bold className="h-4 w-4" />
+							</ToolbarButton>
+							<ToolbarButton
+								onClick={() => editor.chain().focus().toggleItalic().run()}
+								active={editor.isActive("italic")}
+								title="Italic"
+							>
+								<Italic className="h-4 w-4" />
+							</ToolbarButton>
+							<ToolbarButton
+								onClick={() => editor.chain().focus().toggleHighlight().run()}
+								active={editor.isActive("highlight")}
+								title="Highlight"
+							>
+								<Highlighter className="h-4 w-4" />
+							</ToolbarButton>
+							<ToolbarSeparator />
+							<ToolbarButton
+								onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+								active={editor.isActive("heading", { level: 2 })}
+								title="Heading 2"
+							>
+								<Heading2 className="h-4 w-4" />
+							</ToolbarButton>
+							<ToolbarButton
+								onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+								active={editor.isActive("heading", { level: 3 })}
+								title="Heading 3"
+							>
+								<Heading3 className="h-4 w-4" />
+							</ToolbarButton>
+							<ToolbarButton
+								onClick={() => editor.chain().focus().toggleHeading({ level: 4 }).run()}
+								active={editor.isActive("heading", { level: 4 })}
+								title="Heading 4"
+							>
+								<Heading4 className="h-4 w-4" />
+							</ToolbarButton>
+							<ToolbarSeparator />
+							<ToolbarButton
+								onClick={() => editor.chain().focus().toggleBulletList().run()}
+								active={editor.isActive("bulletList")}
+								title="Bullet list"
+							>
+								<List className="h-4 w-4" />
+							</ToolbarButton>
+							<ToolbarButton
+								onClick={() => editor.chain().focus().toggleOrderedList().run()}
+								active={editor.isActive("orderedList")}
+								title="Ordered list"
+							>
+								<ListOrdered className="h-4 w-4" />
+							</ToolbarButton>
+							<ToolbarSeparator />
+							<ToolbarButton
+								onClick={() => editor.chain().focus().toggleBlockquote().run()}
+								active={editor.isActive("blockquote")}
+								title="Block quote"
+							>
+								<TextQuote className="h-4 w-4" />
+							</ToolbarButton>
+							<AdmonitionDropdown
+								onSelect={(type) => editor.chain().focus().toggleAdmonition({ type }).run()}
+								active={editor.isActive("admonition")}
+							/>
+							<ToolbarSeparator />
+							<ToolbarButton onClick={setLink} active={editor.isActive("link")} title="Link">
+								<LinkIcon className="h-4 w-4" />
+							</ToolbarButton>
+							<ToolbarButton
+								onClick={() => editor.chain().focus().setHorizontalRule().run()}
+								title="Horizontal rule"
+							>
+								<Minus className="h-4 w-4" />
+							</ToolbarButton>
+							<ToolbarSeparator />
+							<ToolbarButton
+								onClick={() => editor.chain().focus().clearNodes().unsetAllMarks().run()}
+								title="Clear formatting"
+							>
+								<RemoveFormatting className="h-4 w-4" />
+							</ToolbarButton>
+						</>
+					)}
+					<div className="ml-auto flex">
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									onClick={mode === "markdown" ? switchToWysiwyg : undefined}
+									className={`cursor-pointer rounded-l-md p-2 transition-all duration-150 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
+										mode === "wysiwyg"
+											? "bg-secondary-500 text-white"
+											: "text-muted-foreground hover:bg-secondary-100 hover:text-secondary-700"
+									}`}
+								>
+									<Eye className="h-4 w-4" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent>WYSIWYG</TooltipContent>
+						</Tooltip>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<button
+									type="button"
+									onClick={mode === "wysiwyg" ? switchToMarkdown : undefined}
+									className={`cursor-pointer rounded-r-md p-2 transition-all duration-150 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
+										mode === "markdown"
+											? "bg-secondary-500 text-white"
+											: "text-muted-foreground hover:bg-secondary-100 hover:text-secondary-700"
+									}`}
+								>
+									<Code className="h-4 w-4" />
+								</button>
+							</TooltipTrigger>
+							<TooltipContent>Markdown</TooltipContent>
+						</Tooltip>
+					</div>
+				</div>
+			</TooltipProvider>
+			<div ref={contentRef}>
+				{mode === "wysiwyg" ? (
+					<div
+						className="markdown-editor-scroll overflow-y-auto rounded-b-md border-x border-b border-gray-300"
+						style={{ maxHeight: effectiveMaxHeight }}
+					>
+						<EditorContent editor={editor} />
+					</div>
+				) : (
+					<Textarea
+						ref={textareaRef}
+						value={markdownText}
+						onChange={(e) => {
+							handleMarkdownTextChange(e.target.value)
+							requestAnimationFrame(autoResizeTextarea)
+						}}
+						className="markdown-editor-scroll resize-none overflow-y-auto rounded-t-none border-x border-b border-t-0 border-gray-300 p-4 font-mono text-sm"
+						style={{ minHeight, maxHeight: effectiveMaxHeight }}
+					/>
+				)}
+			</div>
+		</div>
+	)
+}
+
+function ToolbarButton({
+	onClick,
+	active,
+	title,
+	children,
+}: {
+	onClick: () => void
+	active?: boolean
+	title: string
+	children: React.ReactNode
+}) {
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					onClick={onClick}
+					className={`cursor-pointer rounded p-2 transition-all duration-150 hover:bg-secondary-100 hover:text-secondary-700 active:scale-90 active:bg-secondary-200 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
+						active ? "bg-muted text-primary" : "text-muted-foreground"
+					}`}
+				>
+					{children}
+				</button>
+			</TooltipTrigger>
+			<TooltipContent>{title}</TooltipContent>
+		</Tooltip>
+	)
+}
+
+function ToolbarSeparator() {
+	return <div className="mx-1 w-px self-stretch bg-border" />
+}
+
+const admonitionItems: { type: AdmonitionType; label: string; icon: React.ReactNode }[] = [
+	{ type: "note", label: "Note", icon: <Info className="h-4 w-4 text-blue-500" /> },
+	{ type: "tip", label: "Tip", icon: <Lightbulb className="h-4 w-4 text-green-500" /> },
+	{ type: "warning", label: "Warning", icon: <AlertTriangle className="h-4 w-4 text-amber-500" /> },
+	{ type: "danger", label: "Danger", icon: <ShieldAlert className="h-4 w-4 text-red-500" /> },
+]
+
+function AdmonitionDropdown({
+	onSelect,
+	active,
+}: {
+	onSelect: (type: AdmonitionType) => void
+	active: boolean
+}) {
+	return (
+		<DropdownMenu>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<DropdownMenuTrigger asChild>
+						<button
+							type="button"
+							className={`flex cursor-pointer items-center gap-0.5 rounded p-2 transition-all duration-150 hover:bg-secondary-100 hover:text-secondary-700 active:scale-90 active:bg-secondary-200 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
+								active ? "bg-muted text-primary" : "text-muted-foreground"
+							}`}
+						>
+							<Info className="h-4 w-4" />
+							<ChevronDown className="h-3 w-3" />
+						</button>
+					</DropdownMenuTrigger>
+				</TooltipTrigger>
+				<TooltipContent>Callout block</TooltipContent>
+			</Tooltip>
+			<DropdownMenuContent align="start">
+				{admonitionItems.map((item) => (
+					<DropdownMenuItem key={item.type} onClick={() => onSelect(item.type)}>
+						{item.icon}
+						<span className="ml-2">{item.label}</span>
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	)
+}

--- a/apps/admin/src/lib/content-actions.ts
+++ b/apps/admin/src/lib/content-actions.ts
@@ -1,0 +1,115 @@
+"use server"
+
+import { content } from "@mpga/database"
+import type { ActionResult } from "@mpga/types"
+import { eq } from "drizzle-orm"
+
+import { db } from "@/lib/db"
+import { requireAuth } from "@/lib/require-auth"
+
+export interface ContentData {
+	id: number
+	contentType: string
+	title: string
+	contentText: string
+}
+
+export async function getContentAction(contentType: string): Promise<ActionResult<ContentData>> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	try {
+		const results = await db
+			.select({
+				id: content.id,
+				contentType: content.contentType,
+				title: content.title,
+				contentText: content.contentText,
+			})
+			.from(content)
+			.where(eq(content.contentType, contentType))
+
+		if (results.length === 0) {
+			return { success: true }
+		}
+
+		return { success: true, data: results[0] }
+	} catch (error) {
+		console.error("Failed to get content:", error)
+		return { success: false, error: "Failed to get content" }
+	}
+}
+
+export async function saveContentAction(
+	data: {
+		id?: number
+		contentType: string
+		title: string
+		contentText: string
+	},
+	revalidatePath: string,
+): Promise<ActionResult<{ id: number }>> {
+	const userId = await requireAuth()
+	if (!userId) {
+		return { success: false, error: "Unauthorized" }
+	}
+
+	const title = data.title?.trim()
+	if (!title) {
+		return { success: false, error: "Title is required" }
+	}
+
+	try {
+		let id: number
+
+		if (data.id !== undefined) {
+			await db
+				.update(content)
+				.set({
+					title,
+					contentText: data.contentText,
+				})
+				.where(eq(content.id, data.id))
+			id = data.id
+		} else {
+			const result = await db.insert(content).values({
+				contentType: data.contentType,
+				title,
+				contentText: data.contentText,
+			})
+			id = result[0].insertId
+		}
+
+		await revalidatePublicSite(revalidatePath)
+
+		return { success: true, data: { id } }
+	} catch (error) {
+		console.error("Failed to save content:", error)
+		return { success: false, error: "Failed to save content" }
+	}
+}
+
+async function revalidatePublicSite(path: string) {
+	const publicUrl = process.env.PUBLIC_SITE_URL
+	const secret = process.env.REVALIDATE_SECRET
+
+	if (!publicUrl || !secret) {
+		console.warn("PUBLIC_SITE_URL or REVALIDATE_SECRET not configured, skipping revalidation")
+		return
+	}
+
+	try {
+		const res = await fetch(`${publicUrl}/api/revalidate?path=${encodeURIComponent(path)}`, {
+			method: "POST",
+			signal: AbortSignal.timeout(5000),
+			headers: { "x-revalidate-secret": secret },
+		})
+		if (!res.ok) {
+			console.error(`Revalidation failed: ${res.status} ${res.statusText}`)
+		}
+	} catch (error) {
+		console.error("Failed to revalidate public site:", error)
+	}
+}


### PR DESCRIPTION
## Summary
- Add club detail, create, and edit pages with contacts, roles, and payment sections
- Add golf course detail, create, and edit pages
- Add toggleable primary contact flag (star icon) replacing the static badge
- Extract markdown editor and content actions into reusable modules
- Style role badges with secondary palette colors
- Move Archived checkbox to its own row on the club form

## Test plan
- [ ] Navigate to `/members/clubs` and verify list page loads
- [ ] Create a new club and verify redirect to detail page
- [ ] Edit an existing club and verify save
- [ ] Toggle primary contact star and verify toast + UI update
- [ ] Add/remove roles on club contacts
- [ ] Navigate to `/members/golf-courses` and verify CRUD operations
- [ ] Verify markdown editor works on club notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full club management: create/edit clubs, contacts, roles, primary toggles, and payment recording.
  * Golf course management with create/edit/delete and listing UI.
  * Server-driven editable landing pages for Members and Match Play with content editor and preview.
  * New Markdown editor (WYSIWYG + markdown) and revamped Content Editor with preview.

* **Bug Fixes / Style**
  * Minor table/header layout adjustment and improved editor scrollbar styling.

* **Documentation**
  * Added Git commit workflow doc and updated PR review guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->