### PR TITLE
Add preview heading props and fix EC content lookup

### DIFF
--- a/apps/admin/next-env.d.ts
+++ b/apps/admin/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts"
+import "./.next/dev/types/routes.d.ts"
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/admin/src/app/(dashboard)/content/awards/[systemName]/page.tsx
+++ b/apps/admin/src/app/(dashboard)/content/awards/[systemName]/page.tsx
@@ -46,6 +46,7 @@ export default async function AwardPage({ params }: { params: Promise<{ systemNa
 				loadContent={loadDescription}
 				saveContent={saveDescription}
 				showTitle={false}
+				preview={{ heading: "h2" }}
 			/>
 			<WinnersCard initialWinners={winners} awardId={awardData.id} />
 		</div>

--- a/apps/admin/src/app/(dashboard)/content/executive-committee/actions.ts
+++ b/apps/admin/src/app/(dashboard)/content/executive-committee/actions.ts
@@ -28,7 +28,7 @@ export interface ClubOption {
 }
 
 export async function getECContentAction() {
-	return getContentAction("EC")
+	return getContentAction(ContentSystemName.ExecutiveCommittee)
 }
 
 export async function saveECContentAction(data: { id?: number; title: string; content: string }) {

--- a/apps/admin/src/app/(dashboard)/content/executive-committee/page.tsx
+++ b/apps/admin/src/app/(dashboard)/content/executive-committee/page.tsx
@@ -43,7 +43,7 @@ export default async function ExecutiveCommitteePage() {
 			<H1 variant="secondary" className="mb-6">
 				Executive Committee
 			</H1>
-			<ContentEditor loadContent={loadEC} saveContent={saveEC} />
+			<ContentEditor loadContent={loadEC} saveContent={saveEC} preview={{ heading: "h1" }} />
 			<MembersCard initialMembers={members} contacts={contacts} clubs={clubs} />
 		</div>
 	)

--- a/apps/admin/src/app/(dashboard)/content/home/page.tsx
+++ b/apps/admin/src/app/(dashboard)/content/home/page.tsx
@@ -115,9 +115,21 @@ export default function HomePagePage() {
 				<p className="text-muted-foreground">
 					These cards appear below the about section on the home page.
 				</p>
-				<ContentEditor loadContent={loadTournamentsContent} saveContent={saveTournamentsContent} />
-				<ContentEditor loadContent={loadMatchPlayContent} saveContent={saveMatchPlayContent} />
-				<ContentEditor loadContent={loadMembersContent} saveContent={saveMembersContent} />
+				<ContentEditor
+					loadContent={loadTournamentsContent}
+					saveContent={saveTournamentsContent}
+					preview={{ heading: "h3" }}
+				/>
+				<ContentEditor
+					loadContent={loadMatchPlayContent}
+					saveContent={saveMatchPlayContent}
+					preview={{ heading: "h3" }}
+				/>
+				<ContentEditor
+					loadContent={loadMembersContent}
+					saveContent={saveMembersContent}
+					preview={{ heading: "h3" }}
+				/>
 			</section>
 		</div>
 	)

--- a/apps/admin/src/app/(dashboard)/tournaments/[systemName]/description/page.tsx
+++ b/apps/admin/src/app/(dashboard)/tournaments/[systemName]/description/page.tsx
@@ -43,6 +43,7 @@ export default async function EditDescriptionPage({
 				loadContent={loadContent}
 				saveContent={saveContent}
 				showTitle={false}
+				preview={{ heading: "h2" }}
 			/>
 		</div>
 	)

--- a/apps/admin/src/app/(dashboard)/tournaments/[systemName]/overview/page.tsx
+++ b/apps/admin/src/app/(dashboard)/tournaments/[systemName]/overview/page.tsx
@@ -49,6 +49,7 @@ export default async function EditOverviewPage({
 				loadContent={loadContent}
 				saveContent={saveContent}
 				showTitle={false}
+				preview={{ heading: "h2" }}
 			/>
 		</div>
 	)

--- a/apps/admin/src/app/(dashboard)/tournaments/policies/page.tsx
+++ b/apps/admin/src/app/(dashboard)/tournaments/policies/page.tsx
@@ -33,9 +33,9 @@ export default function EditPoliciesPage() {
 				Edit Tournament Policies
 			</H1>
 			<ContentEditor
-				backHref="/tournaments/policies"
 				loadContent={loadPoliciesContent}
 				saveContent={savePoliciesContent}
+				preview={{ heading: "h1" }}
 			/>
 		</div>
 	)


### PR DESCRIPTION
## Summary
- Add `preview` heading level props (`h1`, `h2`, `h3`) to `ContentEditor` across admin content pages for proper heading hierarchy in previews
- Use `ContentSystemName` enum instead of hardcoded `"EC"` string in executive committee content action
- Remove unused `backHref` prop from policies `ContentEditor`
- Auto-updated `next-env.d.ts` dev types path

## Test plan
- [ ] Verify content preview headings render at correct levels on awards, EC, home, tournament description/overview, and policies pages
- [ ] Confirm EC content still loads correctly with enum-based lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live preview functionality to content editors across multiple sections (awards, home, tournaments, policies) with proper heading hierarchy support (h1, h2, h3 levels).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->