### PR TITLE
Add match play navigation, teams page, and mobile history table

### DIFF
--- a/apps/admin/next-env.d.ts
+++ b/apps/admin/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts"
+import "./.next/types/routes.d.ts"
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/public/src/app/match-play/layout.tsx
+++ b/apps/public/src/app/match-play/layout.tsx
@@ -1,0 +1,10 @@
+import { MatchPlayNav } from "@mpga/ui"
+
+export default function MatchPlayLayout({ children }: { children: React.ReactNode }) {
+	return (
+		<>
+			<MatchPlayNav />
+			{children}
+		</>
+	)
+}

--- a/apps/public/src/app/match-play/page.tsx
+++ b/apps/public/src/app/match-play/page.tsx
@@ -1,7 +1,6 @@
-import { ContentCard, H2, MatchPlaySignUp, MatchPlayGroupCards } from "@mpga/ui"
+import { ContentCard, MatchPlaySignUp } from "@mpga/ui"
 
 import { getMatchPlayContent } from "@/lib/queries/content"
-import { getTeamsForYear } from "@/lib/queries/match-play"
 import { getCurrentSeason } from "@/lib/season"
 
 export default async function MatchPlayPage() {
@@ -14,7 +13,7 @@ export default async function MatchPlayPage() {
 	if (deadlineStr) {
 		const deadline = new Date(`${deadlineStr}T23:59:59`)
 		if (!isNaN(deadline.getTime()) && new Date() <= deadline) {
-			showSignUp = false
+			showSignUp = true
 			formattedDeadline = deadline.toLocaleDateString("en-US", {
 				month: "long",
 				day: "numeric",
@@ -23,13 +22,15 @@ export default async function MatchPlayPage() {
 		}
 	}
 
-	const [content, teams] = await Promise.all([
-		getMatchPlayContent(),
-		showSignUp ? Promise.resolve([]) : getTeamsForYear(currentYear),
-	])
+	const content = await getMatchPlayContent()
 
 	return (
-		<main className="mx-auto max-w-6xl px-4 py-8">
+		<div className="mx-auto max-w-6xl px-4 py-8">
+			{showSignUp && (
+				<div className="mb-8">
+					<MatchPlaySignUp year={currentYear} deadline={formattedDeadline} />
+				</div>
+			)}
 			{content && (
 				<ContentCard
 					heading="h1"
@@ -38,14 +39,6 @@ export default async function MatchPlayPage() {
 					className="mb-8"
 				/>
 			)}
-			{showSignUp ? (
-				<MatchPlaySignUp year={currentYear} deadline={formattedDeadline} />
-			) : (
-				<>
-					<H2 className="mb-4 font-semibold text-primary-800">{currentYear} Match Play Groups</H2>
-					<MatchPlayGroupCards teams={teams} year={currentYear} />
-				</>
-			)}
-		</main>
+		</div>
 	)
 }

--- a/apps/public/src/app/match-play/results/page.tsx
+++ b/apps/public/src/app/match-play/results/page.tsx
@@ -18,7 +18,7 @@ export default async function MatchPlayResultsPage() {
 	}))
 
 	return (
-		<main className="mx-auto max-w-4xl px-4 py-8">
+		<div className="mx-auto max-w-4xl px-4 py-8">
 			<H1 className="mb-8">Schedule and Results</H1>
 
 			{documentItems.length > 0 && (
@@ -33,6 +33,6 @@ export default async function MatchPlayResultsPage() {
         </h2> */}
 				<MatchPlayResultsTable results={results} />
 			</section>
-		</main>
+		</div>
 	)
 }

--- a/apps/public/src/app/match-play/rules/page.tsx
+++ b/apps/public/src/app/match-play/rules/page.tsx
@@ -15,9 +15,9 @@ export default async function MatchPlayRulesPage() {
 	])
 
 	return (
-		<main className="mx-auto max-w-4xl px-4 py-8">
+		<div className="mx-auto max-w-4xl px-4 py-8">
 			<H1 className="mb-8">Match Play Rules</H1>
 			<MatchPlayRulesTabs matchPlayRules={matchPlayRules} seniorRules={seniorRules} />
-		</main>
+		</div>
 	)
 }

--- a/apps/public/src/app/match-play/teams/page.tsx
+++ b/apps/public/src/app/match-play/teams/page.tsx
@@ -1,0 +1,16 @@
+import { H1, MatchPlayGroupCards } from "@mpga/ui"
+
+import { getTeamsForYear } from "@/lib/queries/match-play"
+import { getCurrentSeason } from "@/lib/season"
+
+export default async function MatchPlayTeamsPage() {
+	const currentYear = getCurrentSeason()
+	const teams = await getTeamsForYear(currentYear)
+
+	return (
+		<div className="mx-auto max-w-6xl px-4 py-8">
+			<H1 className="mb-4">{currentYear} Match Play Teams</H1>
+			<MatchPlayGroupCards teams={teams} year={currentYear} />
+		</div>
+	)
+}

--- a/packages/ui/src/components/HistoryResultsTable.tsx
+++ b/packages/ui/src/components/HistoryResultsTable.tsx
@@ -1,8 +1,10 @@
 "use client"
 
-import { ChevronDown, ChevronUp } from "lucide-react"
+import { ArrowDownUp, ChevronDown, ChevronUp } from "lucide-react"
 import * as React from "react"
 
+import { Badge } from "./ui/badge"
+import { Button } from "./ui/button"
 import { PageSizeSelect } from "./ui/page-size-select"
 import { Pagination } from "./ui/pagination"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./ui/table"
@@ -89,17 +91,31 @@ export function HistoryResultsTable({ results }: HistoryResultsTableProps) {
 		<div className="space-y-4">
 			{/* Controls row */}
 			<div className="flex items-center justify-between">
-				<PageSizeSelect
-					value={String(pageSize)}
-					onChange={(v) => handlePageSizeChange(v === "all" ? "all" : (Number(v) as 10 | 25 | 50))}
-				/>
+				<div className="flex items-center gap-2">
+					<PageSizeSelect
+						value={String(pageSize)}
+						onChange={(v) =>
+							handlePageSizeChange(v === "all" ? "all" : (Number(v) as 10 | 25 | 50))
+						}
+					/>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={toggleSort}
+						className="md:hidden"
+						aria-label={`Sort by year ${sortOrder === "desc" ? "ascending" : "descending"}`}
+					>
+						<ArrowDownUp className="mr-1 h-4 w-4" />
+						{sortOrder === "desc" ? "Newest" : "Oldest"}
+					</Button>
+				</div>
 				<p className="text-sm text-gray-600">
 					{results.length} {results.length === 1 ? "result" : "results"}
 				</p>
 			</div>
 
-			{/* Table */}
-			<div className="rounded-lg bg-white shadow-sm">
+			{/* Table (desktop) */}
+			<div className="hidden rounded-lg bg-white shadow-sm md:block">
 				<Table className="min-w-full divide-y divide-gray-200">
 					<TableHeader className="bg-primary-50">
 						<TableRow className="hover:bg-transparent">
@@ -165,6 +181,28 @@ export function HistoryResultsTable({ results }: HistoryResultsTableProps) {
 						))}
 					</TableBody>
 				</Table>
+			</div>
+
+			{/* Cards (mobile) */}
+			<div className="space-y-2 md:hidden">
+				{paginatedResults.map((result) => (
+					<div
+						key={result.id}
+						className="rounded-lg border border-gray-200 bg-white px-3 py-2.5 shadow-sm"
+					>
+						<div className="flex items-center justify-between">
+							<div className="flex items-center gap-2">
+								<span className="text-sm font-bold text-primary-900">{result.year}</span>
+								<Badge variant="outline" className="px-1.5 py-0 text-xs">
+									{result.division}
+								</Badge>
+							</div>
+							<span className="text-sm font-medium text-gray-700">{formatScore(result)}</span>
+						</div>
+						<p className="mt-1 text-sm text-gray-900">{formatChampion(result)}</p>
+						<p className="mt-0.5 text-xs text-gray-500">{result.location}</p>
+					</div>
+				))}
 			</div>
 
 			{/* Pagination */}

--- a/packages/ui/src/components/MatchPlayNav.tsx
+++ b/packages/ui/src/components/MatchPlayNav.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+
+const navItems = [
+	{ label: "Overview", href: "/match-play" },
+	{ label: "Teams", href: "/match-play/teams" },
+	{ label: "Results", href: "/match-play/results" },
+	{ label: "Rules", href: "/match-play/rules" },
+]
+
+export function MatchPlayNav() {
+	const pathname = usePathname()
+
+	return (
+		<nav className="overflow-x-auto border-b border-gray-200 print:hidden">
+			<div className="mx-auto flex max-w-6xl px-4">
+				{navItems.map((item) => (
+					<Link
+						key={item.href}
+						href={item.href}
+						className={`whitespace-nowrap px-4 py-2 text-sm font-medium transition-colors ${
+							pathname === item.href
+								? "border-b-2 border-primary-600 text-primary-600"
+								: "text-gray-500 hover:text-gray-700"
+						}`}
+					>
+						{item.label}
+					</Link>
+				))}
+			</div>
+		</nav>
+	)
+}

--- a/packages/ui/src/components/TournamentCard.tsx
+++ b/packages/ui/src/components/TournamentCard.tsx
@@ -2,6 +2,7 @@ import { Calendar, MapPin, ArrowRight, Trophy, History } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
 
+import { Markdown } from "./Markdown"
 import { Card, CardContent, CardHeader } from "./ui/card"
 import { H3 } from "./ui/heading"
 
@@ -25,7 +26,7 @@ export function TournamentCard({
 	historyHref,
 }: TournamentCardProps) {
 	return (
-		<Card>
+		<Card className="overflow-hidden">
 			<CardHeader>
 				<div className="flex items-start gap-4">
 					<div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-gray-100">
@@ -41,18 +42,20 @@ export function TournamentCard({
 							<Trophy className="h-8 w-8 text-gray-400" />
 						)}
 					</div>
-					<H3 className="font-bold">{name}</H3>
+					<div className="min-w-0">
+						<H3 className="font-bold">{name}</H3>
+					</div>
 				</div>
 			</CardHeader>
 			<CardContent>
-				<p className="mb-4 flex-1 line-clamp-3 text-gray-600">{description}</p>
+				<Markdown content={description} className="prose mb-4 flex-1 line-clamp-3 text-gray-600" />
 				{historyHref && (
 					<Link
 						href={historyHref}
 						className="mb-2 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
 					>
 						<History className="h-4 w-4" />
-						View History
+						History
 					</Link>
 				)}
 				<div className="mb-4 space-y-2 text-sm text-gray-500">

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -34,6 +34,7 @@ export { ClubDetailCard, type ClubDetailCardProps } from "./ClubDetailCard"
 export { OfficersCard, type OfficersCardProps, type Officer } from "./OfficersCard"
 export { MatchPlaySignUp, type MatchPlaySignUpProps } from "./MatchPlaySignUp"
 export { MatchPlayRulesTabs, type MatchPlayRulesTabsProps } from "./MatchPlayRulesTabs"
+export { MatchPlayNav } from "./MatchPlayNav"
 export { PrintButton } from "./PrintButton"
 export { NewsList, type NewsListProps } from "./NewsList"
 export {


### PR DESCRIPTION
## Summary
- Add `MatchPlayNav` component with tab-style navigation for match play section pages
- Create shared match-play layout and extract teams into a dedicated `/match-play/teams` page
- Add responsive mobile card view to `HistoryResultsTable` with a sort toggle button
- Render `TournamentCard` description as markdown and fix card overflow
- Move sign-up form above content on the match play overview page

## Test plan
- [ ] Verify match play nav tabs highlight correctly on each sub-page
- [ ] Confirm teams page loads and displays group cards
- [ ] Check history results table renders cards on mobile and table on desktop
- [ ] Verify tournament card descriptions render markdown properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a Match Play navigation bar across Overview, Teams, Results, and Rules.
  * Introduced a dedicated Teams page showing current season teams.
  * Improved History Results on mobile with card-based layout and a quick sort toggle.

* Style
  * Updated Match Play overview to show Sign Up prominently when open.
  * Minor layout adjustments on Results and Rules pages.
  * Tournament cards now render descriptions with Markdown and use “History” label.
  * Improved text truncation and overflow handling in cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->