### PR TITLE
Add production deployment infrastructure for Coolify

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,9 @@ node_modules
 *.md
 .env
 .env.local
+.env.docker
 .DS_Store
+.turbo
+coverage
+.vscode
+.github

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,82 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - "v*"
+      - "public-v*"
+      - "admin-v*"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-public:
+    if: startsWith(github.ref_name, 'v') || startsWith(github.ref_name, 'public-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push public image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/public/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository }}/public:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ github.repository }}/public:latest
+
+  build-admin:
+    if: startsWith(github.ref_name, 'v') || startsWith(github.ref_name, 'admin-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push admin image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/admin/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository }}/admin:${{ github.ref_name }}
+            ${{ env.REGISTRY }}/${{ github.repository }}/admin:latest
+
+  deploy-public:
+    needs: build-public
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Coolify deploy (public)
+        run: |
+          curl -X POST "${{ secrets.COOLIFY_WEBHOOK_URL_PUBLIC }}"
+
+  deploy-admin:
+    needs: build-admin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Coolify deploy (admin)
+        run: |
+          curl -X POST "${{ secrets.COOLIFY_WEBHOOK_URL_ADMIN }}"

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -23,8 +23,14 @@ RUN adduser --system --uid 1001 nextjs
 COPY --from=installer --chown=nextjs:nodejs /app/apps/admin/.next/standalone ./
 COPY --from=installer --chown=nextjs:nodejs /app/apps/admin/.next/static ./apps/admin/.next/static
 COPY --from=installer --chown=nextjs:nodejs /app/apps/admin/public ./apps/admin/public
+COPY --from=installer --chown=nextjs:nodejs /app/packages/database/drizzle ./packages/database/drizzle
+COPY --from=installer --chown=nextjs:nodejs /app/packages/database/migrate.mjs ./packages/database/migrate.mjs
+COPY --chown=nextjs:nodejs apps/admin/start.sh ./start.sh
+RUN chmod +x start.sh
 USER nextjs
 EXPOSE 3001
 ENV PORT=3001
 ENV HOSTNAME="0.0.0.0"
-CMD ["node", "apps/admin/server.js"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+	CMD wget --no-verbose --tries=1 --spider http://localhost:3001/api/health || exit 1
+CMD ["./start.sh"]

--- a/apps/admin/src/app/api/health/route.ts
+++ b/apps/admin/src/app/api/health/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+	return Response.json({ status: "ok" })
+}

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -6,6 +6,7 @@ export async function proxy(request: NextRequest) {
 	const isPublicRoute =
 		request.nextUrl.pathname.startsWith("/login") ||
 		request.nextUrl.pathname.startsWith("/api/auth") ||
+		request.nextUrl.pathname.startsWith("/api/health") ||
 		request.nextUrl.pathname.startsWith("/api/invitations/validate") ||
 		request.nextUrl.pathname.startsWith("/api/invitations/accept") ||
 		request.nextUrl.pathname.startsWith("/accept-invitation") ||

--- a/apps/admin/start.sh
+++ b/apps/admin/start.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+echo "Running database migrations..."
+node packages/database/migrate.mjs
+echo "Starting admin app..."
+exec node apps/admin/server.js

--- a/apps/public/Dockerfile
+++ b/apps/public/Dockerfile
@@ -23,8 +23,14 @@ RUN adduser --system --uid 1001 nextjs
 COPY --from=installer --chown=nextjs:nodejs /app/apps/public/.next/standalone ./
 COPY --from=installer --chown=nextjs:nodejs /app/apps/public/.next/static ./apps/public/.next/static
 COPY --from=installer --chown=nextjs:nodejs /app/apps/public/public ./apps/public/public
+COPY --from=installer --chown=nextjs:nodejs /app/packages/database/drizzle ./packages/database/drizzle
+COPY --from=installer --chown=nextjs:nodejs /app/packages/database/migrate.mjs ./packages/database/migrate.mjs
+COPY --chown=nextjs:nodejs apps/public/start.sh ./start.sh
+RUN chmod +x start.sh
 USER nextjs
 EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
-CMD ["node", "apps/public/server.js"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+	CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1
+CMD ["./start.sh"]

--- a/apps/public/src/app/api/health/route.ts
+++ b/apps/public/src/app/api/health/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+	return Response.json({ status: "ok" })
+}

--- a/apps/public/start.sh
+++ b/apps/public/start.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+echo "Running database migrations..."
+node packages/database/migrate.mjs
+echo "Starting public app..."
+exec node apps/public/server.js

--- a/packages/database/migrate.mjs
+++ b/packages/database/migrate.mjs
@@ -1,0 +1,55 @@
+import { createConnection } from "mysql2/promise"
+import { readFileSync } from "fs"
+import { join } from "path"
+
+const migrationsDir = join(process.cwd(), "packages/database/drizzle")
+
+async function migrate() {
+	const connection = await createConnection({
+		host: process.env.DATABASE_HOST,
+		port: parseInt(process.env.DATABASE_PORT || "3306", 10),
+		user: process.env.DATABASE_USER,
+		password: process.env.DATABASE_PASSWORD,
+		database: process.env.DATABASE_NAME,
+		multipleStatements: false,
+	})
+
+	await connection.execute(`
+		CREATE TABLE IF NOT EXISTS __drizzle_migrations (
+			id SERIAL PRIMARY KEY,
+			hash TEXT NOT NULL,
+			created_at BIGINT
+		)
+	`)
+
+	const journal = JSON.parse(readFileSync(join(migrationsDir, "meta/_journal.json"), "utf-8"))
+
+	const [rows] = await connection.execute("SELECT hash FROM __drizzle_migrations")
+	const applied = new Set(rows.map((r) => r.hash))
+
+	for (const entry of journal.entries) {
+		if (!applied.has(entry.tag)) {
+			const sql = readFileSync(join(migrationsDir, `${entry.tag}.sql`), "utf-8")
+			const statements = sql
+				.split("--> statement-breakpoint")
+				.map((s) => s.trim())
+				.filter(Boolean)
+			for (const stmt of statements) {
+				await connection.execute(stmt)
+			}
+			await connection.execute(
+				"INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)",
+				[entry.tag, Date.now()],
+			)
+			console.log(`Applied migration: ${entry.tag}`)
+		}
+	}
+
+	await connection.end()
+	console.log("Migrations complete")
+}
+
+migrate().catch((err) => {
+	console.error("Migration failed:", err)
+	process.exit(1)
+})


### PR DESCRIPTION
## Summary

- Health check API routes (`/api/health`) for both public and admin apps
- Database migration runner (`packages/database/migrate.mjs`) using mysql2 directly — runs idempotent migrations on container startup
- Startup scripts (`start.sh`) for both apps that run migrations then start the server
- Docker `HEALTHCHECK` directives in production Dockerfiles
- GitHub Actions workflow (`deploy.yml`) for tag-based deployments: builds Docker images on GitHub, pushes to ghcr.io, then triggers Coolify webhooks
- Updated `.dockerignore` with additional exclusions

**Tag convention:**
- `v*` — deploys both apps
- `public-v*` — deploys public only
- `admin-v*` — deploys admin only

## Test plan

- [x] `pnpm format` — clean
- [x] `pnpm lint` — passing
- [x] `pnpm test` — all 84 tests passing
- [x] `pnpm build` — both apps build successfully
- [x] Health endpoints verified: `curl localhost:4000/api/health` and `curl localhost:4100/api/health` both return `{"status":"ok"}`
- [ ] After Coolify setup, test end-to-end with `git tag v0.0.1-test && git push origin v0.0.1-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)