### PR TITLE
Add audit fields to clubs and contacts

### DIFF
--- a/apps/admin/src/app/(dashboard)/members/clubs/[id]/club-contacts-section.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/[id]/club-contacts-section.tsx
@@ -166,7 +166,7 @@ export function ClubContactsSection({ clubId, contacts, onRefresh }: ClubContact
 								<TableHead className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-secondary-900">
 									Roles
 								</TableHead>
-								<TableHead className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-secondary-900">
+								<TableHead className="min-w-40 px-4 py-3 text-xs font-semibold uppercase tracking-wider text-secondary-900">
 									Last Updated
 								</TableHead>
 								<TableHead className="w-10" />
@@ -238,10 +238,12 @@ export function ClubContactsSection({ clubId, contacts, onRefresh }: ClubContact
 											{cc.updateDate ? (
 												<div>
 													<div>
-														{new Date(cc.updateDate.replace(" ", "T")).toLocaleDateString("en-US", {
+														{new Date(cc.updateDate.replace(" ", "T")).toLocaleString("en-US", {
 															year: "numeric",
 															month: "short",
 															day: "numeric",
+															hour: "numeric",
+															minute: "2-digit",
 														})}
 													</div>
 													{cc.updateBy && (

--- a/apps/admin/src/app/(dashboard)/members/clubs/[id]/club-contacts-section.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/[id]/club-contacts-section.tsx
@@ -29,7 +29,8 @@ import {
 	TableRow,
 	toast,
 } from "@mpga/ui"
-import { Star, Trash2, X } from "lucide-react"
+import { Pencil, Star, Trash2, X } from "lucide-react"
+import Link from "next/link"
 import { useEffect, useState } from "react"
 
 import {
@@ -255,39 +256,46 @@ export function ClubContactsSection({ clubId, contacts, onRefresh }: ClubContact
 											)}
 										</TableCell>
 										<TableCell className="px-4 py-3">
-											<AlertDialog>
-												<AlertDialogTrigger asChild>
-													<Button
-														type="button"
-														variant="ghost"
-														size="sm"
-														disabled={removing === cc.clubContactId}
-													>
-														<Trash2 className="h-4 w-4 text-red-500" />
-													</Button>
-												</AlertDialogTrigger>
-												<AlertDialogContent>
-													<AlertDialogHeader>
-														<AlertDialogTitle>Remove Contact</AlertDialogTitle>
-														<AlertDialogDescription>
-															Remove {cc.firstName} {cc.lastName} from this club? The contact record
-															itself will not be deleted.
-														</AlertDialogDescription>
-													</AlertDialogHeader>
-													<AlertDialogFooter>
-														<AlertDialogCancel>Cancel</AlertDialogCancel>
-														<AlertDialogAction
-															onClick={(e) => {
-																e.preventDefault()
-																handleRemoveContact(cc.clubContactId)
-															}}
-															className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+											<div className="flex items-center">
+												<Button type="button" variant="ghost" size="sm" asChild>
+													<Link href={`/members/contacts/${cc.contactId}`}>
+														<Pencil className="h-4 w-4 text-secondary-500" />
+													</Link>
+												</Button>
+												<AlertDialog>
+													<AlertDialogTrigger asChild>
+														<Button
+															type="button"
+															variant="ghost"
+															size="sm"
+															disabled={removing === cc.clubContactId}
 														>
-															Remove
-														</AlertDialogAction>
-													</AlertDialogFooter>
-												</AlertDialogContent>
-											</AlertDialog>
+															<Trash2 className="h-4 w-4 text-red-500" />
+														</Button>
+													</AlertDialogTrigger>
+													<AlertDialogContent>
+														<AlertDialogHeader>
+															<AlertDialogTitle>Remove Contact</AlertDialogTitle>
+															<AlertDialogDescription>
+																Remove {cc.firstName} {cc.lastName} from this club? The contact
+																record itself will not be deleted.
+															</AlertDialogDescription>
+														</AlertDialogHeader>
+														<AlertDialogFooter>
+															<AlertDialogCancel>Cancel</AlertDialogCancel>
+															<AlertDialogAction
+																onClick={(e) => {
+																	e.preventDefault()
+																	handleRemoveContact(cc.clubContactId)
+																}}
+																className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+															>
+																Remove
+															</AlertDialogAction>
+														</AlertDialogFooter>
+													</AlertDialogContent>
+												</AlertDialog>
+											</div>
 										</TableCell>
 									</TableRow>
 								)

--- a/apps/admin/src/app/(dashboard)/members/clubs/[id]/club-contacts-section.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/[id]/club-contacts-section.tsx
@@ -166,6 +166,9 @@ export function ClubContactsSection({ clubId, contacts, onRefresh }: ClubContact
 								<TableHead className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-secondary-900">
 									Roles
 								</TableHead>
+								<TableHead className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-secondary-900">
+									Last Updated
+								</TableHead>
 								<TableHead className="w-10" />
 							</TableRow>
 						</TableHeader>
@@ -230,6 +233,24 @@ export function ClubContactsSection({ clubId, contacts, onRefresh }: ClubContact
 													</Select>
 												)}
 											</div>
+										</TableCell>
+										<TableCell className="px-4 py-3 text-xs">
+											{cc.updateDate ? (
+												<div>
+													<div>
+														{new Date(cc.updateDate.replace(" ", "T")).toLocaleDateString("en-US", {
+															year: "numeric",
+															month: "short",
+															day: "numeric",
+														})}
+													</div>
+													{cc.updateBy && (
+														<div className="text-muted-foreground">{cc.updateBy}</div>
+													)}
+												</div>
+											) : (
+												"-"
+											)}
 										</TableCell>
 										<TableCell className="px-4 py-3">
 											<AlertDialog>

--- a/apps/admin/src/app/(dashboard)/members/clubs/[id]/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/[id]/page.tsx
@@ -30,6 +30,17 @@ export default function EditClubPage() {
 	const clubId = Number(params.id)
 	const currentYear = new Date().getFullYear()
 
+	const fetchClub = useCallback(async () => {
+		try {
+			const result = await getClubAction(clubId)
+			if (result.success && result.data) {
+				setClub(result.data)
+			}
+		} catch (err) {
+			console.error("Failed to fetch club:", err)
+		}
+	}, [clubId])
+
 	const fetchContacts = useCallback(async () => {
 		try {
 			const result = await listClubContactsAction(clubId)
@@ -102,7 +113,7 @@ export default function EditClubPage() {
 	return (
 		<div className="mx-auto max-w-6xl space-y-6">
 			<H1 variant="secondary">Edit Club</H1>
-			<ClubForm club={club} golfCourses={golfCourses} />
+			<ClubForm club={club} golfCourses={golfCourses} onRefresh={fetchClub} />
 			<ClubContactsSection clubId={clubId} contacts={contacts} onRefresh={fetchContacts} />
 			<ClubPaymentSection
 				clubId={clubId}

--- a/apps/admin/src/app/(dashboard)/members/clubs/club-form.tsx
+++ b/apps/admin/src/app/(dashboard)/members/clubs/club-form.tsx
@@ -24,9 +24,10 @@ import { type ClubData, type GolfCourseOption, saveClubAction } from "./actions"
 interface ClubFormProps {
 	club?: ClubData
 	golfCourses: GolfCourseOption[]
+	onRefresh?: () => void
 }
 
-export function ClubForm({ club: existingClub, golfCourses }: ClubFormProps) {
+export function ClubForm({ club: existingClub, golfCourses, onRefresh }: ClubFormProps) {
 	const router = useRouter()
 	const [saving, setSaving] = useState(false)
 	const [error, setError] = useState<string | null>(null)
@@ -65,6 +66,7 @@ export function ClubForm({ club: existingClub, golfCourses }: ClubFormProps) {
 			if (result.success && result.data) {
 				if (existingClub) {
 					toast.success("Club updated")
+					onRefresh?.()
 				} else {
 					toast.success("Club created")
 					router.push(`/members/clubs/${result.data.id}`)
@@ -178,6 +180,19 @@ export function ClubForm({ club: existingClub, golfCourses }: ClubFormProps) {
 							</Button>
 						</div>
 					</div>
+					{existingClub?.updateDate && (
+						<p className="pt-2 text-right text-xs text-gray-400">
+							Last updated{" "}
+							{new Date(existingClub.updateDate.replace(" ", "T") + "Z").toLocaleString("en-US", {
+								year: "numeric",
+								month: "short",
+								day: "numeric",
+								hour: "numeric",
+								minute: "2-digit",
+							})}
+							{existingClub.updateBy && ` by ${existingClub.updateBy}`}
+						</p>
+					)}
 				</form>
 			</CardContent>
 		</Card>

--- a/apps/admin/src/app/(dashboard)/members/contacts/[id]/contact-clubs-section.tsx
+++ b/apps/admin/src/app/(dashboard)/members/contacts/[id]/contact-clubs-section.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { Badge, Card, CardContent, CardHeader, CardTitle } from "@mpga/ui"
+import { Star } from "lucide-react"
+import Link from "next/link"
+
+import type { ContactClubData } from "../actions"
+
+interface ContactClubsSectionProps {
+	clubs: ContactClubData[]
+}
+
+export function ContactClubsSection({ clubs }: ContactClubsSectionProps) {
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="font-heading text-xl">Club Associations</CardTitle>
+			</CardHeader>
+			<CardContent>
+				{clubs.length === 0 ? (
+					<p className="text-sm text-gray-500">Not associated with any clubs.</p>
+				) : (
+					<div className="divide-y divide-gray-100">
+						{clubs.map((c) => (
+							<div key={c.clubId} className="flex items-center gap-3 py-3 first:pt-0 last:pb-0">
+								{c.isPrimary && (
+									<Star className="h-4 w-4 shrink-0 text-yellow-500" fill="currentColor" />
+								)}
+								<Link
+									href={`/members/clubs/${c.clubId}`}
+									className="font-medium text-secondary-600 hover:underline"
+								>
+									{c.clubName}
+								</Link>
+								{c.roles.map((role) => (
+									<Badge
+										key={role}
+										variant="outline"
+										className="border-secondary-200 bg-secondary-100"
+									>
+										{role}
+									</Badge>
+								))}
+							</div>
+						))}
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	)
+}

--- a/apps/admin/src/app/(dashboard)/members/contacts/[id]/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/contacts/[id]/page.tsx
@@ -4,21 +4,34 @@ import { H1 } from "@mpga/ui"
 import { useParams, useRouter } from "next/navigation"
 import { useCallback, useEffect, useState } from "react"
 
-import { type ContactData, getContactAction } from "../actions"
+import {
+	type ContactClubData,
+	type ContactData,
+	getContactAction,
+	getContactClubsAction,
+} from "../actions"
 import { ContactForm } from "../contact-form"
+import { ContactClubsSection } from "./contact-clubs-section"
 
 export default function EditContactPage() {
 	const params = useParams()
 	const router = useRouter()
 	const [contact, setContact] = useState<ContactData | null>(null)
+	const [clubs, setClubs] = useState<ContactClubData[]>([])
 	const [loading, setLoading] = useState(true)
 	const contactId = Number(params.id)
 
 	const fetchContact = useCallback(async () => {
 		try {
-			const result = await getContactAction(contactId)
-			if (result.success && result.data) {
-				setContact(result.data)
+			const [contactResult, clubsResult] = await Promise.all([
+				getContactAction(contactId),
+				getContactClubsAction(contactId),
+			])
+			if (contactResult.success && contactResult.data) {
+				setContact(contactResult.data)
+			}
+			if (clubsResult.success && clubsResult.data) {
+				setClubs(clubsResult.data)
 			}
 		} catch (err) {
 			console.error("Failed to fetch contact:", err)
@@ -33,11 +46,18 @@ export default function EditContactPage() {
 
 		async function load() {
 			try {
-				const result = await getContactAction(contactId)
-				if (result.success && result.data) {
-					setContact(result.data)
+				const [contactResult, clubsResult] = await Promise.all([
+					getContactAction(contactId),
+					getContactClubsAction(contactId),
+				])
+				if (contactResult.success && contactResult.data) {
+					setContact(contactResult.data)
 				} else {
 					router.push("/members/contacts")
+					return
+				}
+				if (clubsResult.success && clubsResult.data) {
+					setClubs(clubsResult.data)
 				}
 			} catch (err) {
 				console.error("Failed to fetch contact:", err)
@@ -63,11 +83,12 @@ export default function EditContactPage() {
 	}
 
 	return (
-		<div className="mx-auto max-w-4xl">
+		<div className="mx-auto max-w-4xl space-y-6">
 			<H1 variant="secondary" className="mb-6">
 				Edit Contact
 			</H1>
 			<ContactForm contact={contact} onRefresh={fetchContact} />
+			<ContactClubsSection clubs={clubs} />
 		</div>
 	)
 }

--- a/apps/admin/src/app/(dashboard)/members/contacts/[id]/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/contacts/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { H1 } from "@mpga/ui"
 import { useParams, useRouter } from "next/navigation"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 import { type ContactData, getContactAction } from "../actions"
 import { ContactForm } from "../contact-form"
@@ -12,17 +12,28 @@ export default function EditContactPage() {
 	const router = useRouter()
 	const [contact, setContact] = useState<ContactData | null>(null)
 	const [loading, setLoading] = useState(true)
+	const contactId = Number(params.id)
+
+	const fetchContact = useCallback(async () => {
+		try {
+			const result = await getContactAction(contactId)
+			if (result.success && result.data) {
+				setContact(result.data)
+			}
+		} catch (err) {
+			console.error("Failed to fetch contact:", err)
+		}
+	}, [contactId])
 
 	useEffect(() => {
-		async function fetchContact() {
-			const id = Number(params.id)
-			if (isNaN(id)) {
-				router.push("/members/contacts")
-				return
-			}
+		if (isNaN(contactId)) {
+			router.push("/members/contacts")
+			return
+		}
 
+		async function load() {
 			try {
-				const result = await getContactAction(id)
+				const result = await getContactAction(contactId)
 				if (result.success && result.data) {
 					setContact(result.data)
 				} else {
@@ -36,8 +47,8 @@ export default function EditContactPage() {
 			}
 		}
 
-		fetchContact()
-	}, [params.id, router])
+		load()
+	}, [contactId, router])
 
 	if (loading) {
 		return (
@@ -56,7 +67,7 @@ export default function EditContactPage() {
 			<H1 variant="secondary" className="mb-6">
 				Edit Contact
 			</H1>
-			<ContactForm contact={contact} />
+			<ContactForm contact={contact} onRefresh={fetchContact} />
 		</div>
 	)
 }

--- a/apps/admin/src/app/(dashboard)/members/contacts/actions.ts
+++ b/apps/admin/src/app/(dashboard)/members/contacts/actions.ts
@@ -11,7 +11,7 @@ import {
 	classifyClubContact,
 	classifyCommittee,
 } from "@/lib/merge-contacts"
-import { requireAuth } from "@/lib/require-auth"
+import { requireAuth, requireAuthEmail } from "@/lib/require-auth"
 
 interface ContactInput {
 	id?: number
@@ -41,6 +41,8 @@ export interface ContactData {
 	zip: string | null
 	notes: string | null
 	sendEmail: boolean
+	updateDate: string | null
+	updateBy: string | null
 }
 
 export async function listContactsAction(): Promise<ActionResult<ContactData[]>> {
@@ -64,6 +66,8 @@ export async function listContactsAction(): Promise<ActionResult<ContactData[]>>
 				zip: contact.zip,
 				notes: contact.notes,
 				sendEmail: contact.sendEmail,
+				updateDate: contact.updateDate,
+				updateBy: contact.updateBy,
 			})
 			.from(contact)
 			.orderBy(asc(contact.lastName), asc(contact.firstName))
@@ -96,6 +100,8 @@ export async function getContactAction(id: number): Promise<ActionResult<Contact
 				zip: contact.zip,
 				notes: contact.notes,
 				sendEmail: contact.sendEmail,
+				updateDate: contact.updateDate,
+				updateBy: contact.updateBy,
 			})
 			.from(contact)
 			.where(eq(contact.id, id))
@@ -112,8 +118,8 @@ export async function getContactAction(id: number): Promise<ActionResult<Contact
 }
 
 export async function saveContactAction(data: ContactInput): Promise<ActionResult<{ id: number }>> {
-	const userId = await requireAuth()
-	if (!userId) {
+	const email = await requireAuthEmail()
+	if (!email) {
 		return { success: false, error: "Unauthorized" }
 	}
 
@@ -123,6 +129,8 @@ export async function saveContactAction(data: ContactInput): Promise<ActionResul
 	if (!firstName || !lastName) {
 		return { success: false, error: "First name and last name are required" }
 	}
+
+	const now = new Date().toISOString().replace("T", " ").replace("Z", "")
 
 	try {
 		if (data.id !== undefined) {
@@ -140,6 +148,8 @@ export async function saveContactAction(data: ContactInput): Promise<ActionResul
 					zip: data.zip ?? null,
 					notes: data.notes ?? null,
 					sendEmail: data.sendEmail ?? true,
+					updateDate: now,
+					updateBy: email,
 				})
 				.where(eq(contact.id, data.id))
 
@@ -157,6 +167,8 @@ export async function saveContactAction(data: ContactInput): Promise<ActionResul
 				zip: data.zip ?? null,
 				notes: data.notes ?? null,
 				sendEmail: data.sendEmail ?? true,
+				updateDate: now,
+				updateBy: email,
 			})
 
 			return { success: true, data: { id: result[0].insertId } }
@@ -195,6 +207,8 @@ export async function findDuplicatesAction(): Promise<ActionResult<DuplicateGrou
 				zip: contact.zip,
 				notes: contact.notes,
 				sendEmail: contact.sendEmail,
+				updateDate: contact.updateDate,
+				updateBy: contact.updateBy,
 			})
 			.from(contact)
 			.orderBy(asc(contact.lastName), asc(contact.firstName))
@@ -211,8 +225,8 @@ export async function mergeContactsAction(
 	targetId: number,
 	sourceIds: number[],
 ): Promise<ActionResult> {
-	const userId = await requireAuth()
-	if (!userId) {
+	const email = await requireAuthEmail()
+	if (!email) {
 		return { success: false, error: "Unauthorized" }
 	}
 
@@ -233,10 +247,12 @@ export async function mergeContactsAction(
 			// 2. Fetch source contacts and copy missing data to target
 			const sources = await tx.select().from(contact).where(inArray(contact.id, sourceIds))
 
+			const now = new Date().toISOString().replace("T", " ").replace("Z", "")
 			const updates = buildMergeFieldUpdates(target, sources)
-			if (Object.keys(updates).length > 0) {
-				await tx.update(contact).set(updates).where(eq(contact.id, targetId))
-			}
+			await tx
+				.update(contact)
+				.set({ ...updates, updateDate: now, updateBy: email })
+				.where(eq(contact.id, targetId))
 
 			// 3. Reassign clubContact rows
 			const targetClubContacts = await tx
@@ -258,7 +274,7 @@ export async function mergeContactsAction(
 					} else {
 						await tx
 							.update(clubContact)
-							.set({ contactId: targetId })
+							.set({ contactId: targetId, updateDate: now, updateBy: email })
 							.where(eq(clubContact.id, scc.id))
 						targetClubIds.add(scc.clubId)
 					}

--- a/apps/admin/src/app/(dashboard)/members/contacts/contact-form.tsx
+++ b/apps/admin/src/app/(dashboard)/members/contacts/contact-form.tsx
@@ -31,9 +31,10 @@ import { type ContactData, deleteContactAction, saveContactAction } from "./acti
 
 interface ContactFormProps {
 	contact?: ContactData
+	onRefresh?: () => void
 }
 
-export function ContactForm({ contact }: ContactFormProps) {
+export function ContactForm({ contact, onRefresh }: ContactFormProps) {
 	const router = useRouter()
 	const [saving, setSaving] = useState(false)
 	const [deleting, setDeleting] = useState(false)
@@ -80,8 +81,13 @@ export function ContactForm({ contact }: ContactFormProps) {
 			})
 
 			if (result.success) {
-				toast.success(contact ? "Contact updated" : "Contact created")
-				router.push("/members/contacts")
+				if (contact) {
+					toast.success("Contact updated")
+					onRefresh?.()
+				} else {
+					toast.success("Contact created")
+					router.push(`/members/contacts/${result.data!.id}`)
+				}
 			} else {
 				setError(result.error ?? "Failed to save contact")
 			}
@@ -244,7 +250,7 @@ export function ContactForm({ contact }: ContactFormProps) {
 					{/* Action buttons */}
 					<div className="flex justify-between pt-4">
 						{/* Delete button - only shown when editing */}
-						{contact && (
+						{contact?.id && (
 							<AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
 								<AlertDialogTrigger asChild>
 									<Button type="button" variant="destructive">
@@ -278,7 +284,7 @@ export function ContactForm({ contact }: ContactFormProps) {
 						)}
 
 						{/* Spacer when no delete button */}
-						{!contact && <div />}
+						{!contact?.id && <div />}
 
 						{/* Save/Cancel buttons on the right */}
 						<div className="flex gap-2">
@@ -290,6 +296,19 @@ export function ContactForm({ contact }: ContactFormProps) {
 							</Button>
 						</div>
 					</div>
+					{contact?.updateDate && (
+						<p className="pt-2 text-right text-xs text-gray-400">
+							Last updated{" "}
+							{new Date(contact.updateDate.replace(" ", "T") + "Z").toLocaleString("en-US", {
+								year: "numeric",
+								month: "short",
+								day: "numeric",
+								hour: "numeric",
+								minute: "2-digit",
+							})}
+							{contact.updateBy && ` by ${contact.updateBy}`}
+						</p>
+					)}
 				</form>
 			</CardContent>
 		</Card>

--- a/apps/admin/src/app/club-contact/edit-club/[clubId]/club-contacts-section.tsx
+++ b/apps/admin/src/app/club-contact/edit-club/[clubId]/club-contacts-section.tsx
@@ -260,10 +260,12 @@ export function ClubContactsSection({ clubId, initialContacts }: ClubContactsSec
 									{cc.updateDate && (
 										<p className="text-muted-foreground mt-2 text-xs">
 											Updated{" "}
-											{new Date(cc.updateDate.replace(" ", "T")).toLocaleDateString("en-US", {
+											{new Date(cc.updateDate.replace(" ", "T")).toLocaleString("en-US", {
 												year: "numeric",
 												month: "short",
 												day: "numeric",
+												hour: "numeric",
+												minute: "2-digit",
 											})}
 										</p>
 									)}

--- a/apps/admin/src/app/club-contact/edit-club/[clubId]/club-contacts-section.tsx
+++ b/apps/admin/src/app/club-contact/edit-club/[clubId]/club-contacts-section.tsx
@@ -257,6 +257,16 @@ export function ClubContactsSection({ clubId, initialContacts }: ClubContactsSec
 											</Select>
 										)}
 									</div>
+									{cc.updateDate && (
+										<p className="text-muted-foreground mt-2 text-xs">
+											Updated{" "}
+											{new Date(cc.updateDate.replace(" ", "T")).toLocaleDateString("en-US", {
+												year: "numeric",
+												month: "short",
+												day: "numeric",
+											})}
+										</p>
+									)}
 								</div>
 							)
 						})}

--- a/apps/admin/src/app/club-contact/types.ts
+++ b/apps/admin/src/app/club-contact/types.ts
@@ -31,6 +31,8 @@ export interface ClubContactData {
 	primaryPhone: string | null
 	isPrimary: boolean
 	roles: { id: number; role: string }[]
+	updateDate: string | null
+	updateBy: string | null
 }
 
 export interface ContactSearchResult {

--- a/apps/admin/src/lib/__tests__/find-duplicates.test.ts
+++ b/apps/admin/src/lib/__tests__/find-duplicates.test.ts
@@ -17,6 +17,8 @@ function makeContact(
 		zip: null,
 		notes: null,
 		sendEmail: true,
+		updateDate: null,
+		updateBy: null,
 		...overrides,
 	}
 }

--- a/apps/admin/src/lib/__tests__/merge-contacts.test.ts
+++ b/apps/admin/src/lib/__tests__/merge-contacts.test.ts
@@ -17,6 +17,8 @@ function makeContact(
 		zip: null,
 		notes: null,
 		sendEmail: true,
+		updateDate: null,
+		updateBy: null,
 		...overrides,
 	}
 }

--- a/apps/admin/src/lib/require-auth.ts
+++ b/apps/admin/src/lib/require-auth.ts
@@ -13,6 +13,17 @@ export async function requireAuth(): Promise<string | null> {
 	return session.user.id
 }
 
+export async function requireAuthEmail(): Promise<string | null> {
+	const headersList = await headers()
+	const session = await auth.api.getSession({ headers: headersList })
+
+	if (!session?.user || (session.user.role !== "admin" && session.user.role !== "super_admin")) {
+		return null
+	}
+
+	return session.user.email
+}
+
 export async function requireSuperAdmin(): Promise<string | null> {
 	const headersList = await headers()
 	const session = await auth.api.getSession({ headers: headersList })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,8 @@ services:
       context: .
       dockerfile: apps/admin/Dockerfile.dev
     environment:
-      - NODE_OPTIONS=--max-old-space-size=3072
-    mem_limit: 4g
+      - NODE_OPTIONS=--max-old-space-size=5120
+    mem_limit: 6g
     ports:
       - "4100:4100"
     volumes:

--- a/e2e/admin/audit-fields.spec.ts
+++ b/e2e/admin/audit-fields.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test"
+
+const adminEmail = process.env.E2E_ADMIN_EMAIL ?? "admin@mpga.net"
+
+test.describe("Audit fields", () => {
+	test("club form shows Last updated after save", async ({ page }) => {
+		await page.goto("/members/clubs/130", { waitUntil: "domcontentloaded" })
+		await expect(page.getByRole("heading", { name: "Edit Club" })).toBeVisible({
+			timeout: 15000,
+		})
+
+		await page.getByRole("button", { name: "Save" }).click()
+
+		const auditText = page.getByText(/Last updated/)
+		await expect(auditText).toBeVisible({ timeout: 15000 })
+		await expect(auditText).toContainText(`by ${adminEmail}`)
+	})
+
+	test("contact form shows Last updated after save", async ({ page }) => {
+		await page.goto("/members/contacts/1047", { waitUntil: "domcontentloaded" })
+		await expect(page.getByRole("heading", { name: "Edit Contact" })).toBeVisible({
+			timeout: 15000,
+		})
+
+		await page.getByRole("button", { name: "Save" }).click()
+
+		const auditText = page.getByText(/Last updated/)
+		await expect(auditText).toBeVisible({ timeout: 15000 })
+		await expect(auditText).toContainText(`by ${adminEmail}`)
+	})
+})

--- a/e2e/admin/audit-fields.spec.ts
+++ b/e2e/admin/audit-fields.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test"
+import { type Locator, type Page, expect, test } from "@playwright/test"
 
 const adminEmail = process.env.E2E_ADMIN_EMAIL ?? "admin@mpga.net"
 
@@ -27,5 +27,75 @@ test.describe("Audit fields", () => {
 		const auditText = page.getByText(/Last updated/)
 		await expect(auditText).toBeVisible({ timeout: 15000 })
 		await expect(auditText).toContainText(`by ${adminEmail}`)
+	})
+})
+
+test.describe("Club contact audit fields", () => {
+	test.describe.configure({ mode: "serial" })
+
+	const today = new Date().toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	})
+
+	async function navigateToClub(page: Page) {
+		await page.goto("/members/clubs/130", { waitUntil: "domcontentloaded" })
+		await expect(page.getByRole("heading", { name: "Edit Club" })).toBeVisible({
+			timeout: 15000,
+		})
+		const row = page.getByRole("row").filter({ hasText: "Derek White" })
+		await row.scrollIntoViewIfNeeded()
+		return row
+	}
+
+	async function selectRole(page: Page, row: Locator, roleName: string) {
+		const combobox = row.getByRole("combobox")
+		await combobox.scrollIntoViewIfNeeded()
+		await combobox.click()
+		// Radix Select dropdown may extend past the viewport; use JS click to bypass checks
+		await page.getByRole("option", { name: roleName, exact: true }).evaluate((el) => {
+			;(el as HTMLElement).click()
+		})
+	}
+
+	async function removeRole(row: Locator, roleName: string) {
+		// The badge div contains the role text and an X button
+		const badge = row.getByText(roleName, { exact: true })
+		await badge.getByRole("button").click()
+	}
+
+	async function assertAuditUpdated(row: Locator) {
+		await expect(row.getByText(today)).toBeVisible({ timeout: 10000 })
+		await expect(row.getByText(adminEmail)).toBeVisible()
+	}
+
+	test("Last Updated reflects role addition", async ({ page }) => {
+		const row = await navigateToClub(page)
+
+		await selectRole(page, row, "Owner")
+
+		await assertAuditUpdated(row)
+	})
+
+	test("Last Updated reflects role removal", async ({ page }) => {
+		const row = await navigateToClub(page)
+
+		// Remove the "Owner" role added by the previous test
+		await removeRole(row, "Owner")
+
+		await assertAuditUpdated(row)
+	})
+
+	test("Last Updated reflects toggling primary contact", async ({ page }) => {
+		const row = await navigateToClub(page)
+
+		// Toggle primary status
+		await row.getByTitle(/primary/).click()
+
+		await assertAuditUpdated(row)
+
+		// Cleanup: toggle back
+		await row.getByTitle(/primary/).click()
 	})
 })

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -12,6 +12,7 @@ export default async function globalSetup() {
 		"http://localhost:4100/accept-invitation/warmup",
 		"http://localhost:4100/",
 		"http://localhost:4100/members/clubs",
+		"http://localhost:4100/members/contacts",
 	]
 
 	console.log("Warming up dev servers...")

--- a/packages/database/src/schema/schema.ts
+++ b/packages/database/src/schema/schema.ts
@@ -61,6 +61,8 @@ export const club = mysqlTable(
 		size: int(),
 		systemName: varchar({ length: 50 }),
 		archived: boolean().notNull(),
+		updateDate: datetime({ mode: "string", fsp: 6 }),
+		updateBy: varchar({ length: 100 }),
 	},
 	(table) => [primaryKey({ columns: [table.id], name: "club_id" })],
 )
@@ -78,6 +80,8 @@ export const clubContact = mysqlTable(
 		isPrimary: boolean().notNull(),
 		notes: varchar({ length: 150 }),
 		userId: int(),
+		updateDate: datetime({ mode: "string", fsp: 6 }),
+		updateBy: varchar({ length: 100 }),
 	},
 	(table) => [primaryKey({ columns: [table.id], name: "clubContact_id" })],
 )
@@ -124,6 +128,8 @@ export const contact = mysqlTable(
 		zip: varchar({ length: 10 }),
 		notes: longtext(),
 		sendEmail: boolean().notNull(),
+		updateDate: datetime({ mode: "string", fsp: 6 }),
+		updateBy: varchar({ length: 100 }),
 	},
 	(table) => [primaryKey({ columns: [table.id], name: "contact_id" })],
 )


### PR DESCRIPTION
## Summary
- Adds `updateDate`/`updateBy` audit columns to club, clubContact, and contact tables
- Save actions now record the current user's email and timestamp on every save
- Both admin and club-contact forms display "Last updated {date} by {email}" after save
- Includes e2e tests verifying audit text appears after saving clubs and contacts
- Bumps admin container memory (4GB → 6GB) to prevent OOM kills during test runs

## Test plan
- [x] e2e: club form shows "Last updated" with admin email after save
- [x] e2e: contact form shows "Last updated" with admin email after save
- [x] All 16 e2e tests pass
- [x] All unit tests pass (find-duplicates, merge-contacts, tiptap)
- [x] TypeScript strict mode passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)