### PR TITLE
Match play results: filter, search, pagination

### DIFF
--- a/packages/ui/src/components/MatchPlayGroupCards.tsx
+++ b/packages/ui/src/components/MatchPlayGroupCards.tsx
@@ -35,7 +35,6 @@ export interface MatchPlayGroupCardsProps {
 
 export function MatchPlayGroupCards({ teams, year, onRequestCaptains }: MatchPlayGroupCardsProps) {
 	const [dialogOpen, setDialogOpen] = useState(false)
-	const [resultsDialogOpen, setResultsDialogOpen] = useState(false)
 	const [selectedGroup, setSelectedGroup] = useState("")
 	const [email, setEmail] = useState("")
 	const [loading, setLoading] = useState(false)
@@ -152,23 +151,13 @@ export function MatchPlayGroupCards({ teams, year, onRequestCaptains }: MatchPla
 										</li>
 									))}
 								</ul>
-								<div className="flex gap-2">
-									{onRequestCaptains && (
+								{onRequestCaptains && (
+									<div className="flex gap-2">
 										<Button variant="outline" size="sm" onClick={() => openDialog(groupName)}>
 											Captains
 										</Button>
-									)}
-									<Button
-										variant="outline"
-										size="sm"
-										onClick={() => {
-											setSelectedGroup(groupName)
-											setResultsDialogOpen(true)
-										}}
-									>
-										Enter Results
-									</Button>
-								</div>
+									</div>
+								)}
 							</CardContent>
 						</Card>
 					)
@@ -213,17 +202,6 @@ export function MatchPlayGroupCards({ teams, year, onRequestCaptains }: MatchPla
 							</div>
 						</form>
 					)}
-				</DialogContent>
-			</Dialog>
-
-			<Dialog open={resultsDialogOpen} onOpenChange={setResultsDialogOpen}>
-				<DialogContent className="sm:max-w-md">
-					<DialogHeader>
-						<DialogTitle className="font-heading">Enter Results — {selectedGroup}</DialogTitle>
-					</DialogHeader>
-					<div className="py-4 text-center">
-						<p className="text-sm text-gray-500">Coming Soon</p>
-					</div>
 				</DialogContent>
 			</Dialog>
 		</>

--- a/packages/ui/src/components/MatchPlayResultsTable.tsx
+++ b/packages/ui/src/components/MatchPlayResultsTable.tsx
@@ -3,7 +3,10 @@
 import * as React from "react"
 
 import { Badge } from "./ui/badge"
-import { H3 } from "./ui/heading"
+import { PageSizeSelect } from "./ui/page-size-select"
+import { Pagination } from "./ui/pagination"
+import { SearchInput } from "./ui/search-input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./ui/table"
 
 export interface MatchPlayResultRow {
@@ -22,6 +25,10 @@ export interface MatchPlayResultsTableProps {
 	results: MatchPlayResultRow[]
 }
 
+type PageSize = 10 | 25 | 50 | "all"
+
+const ALL_GROUPS = "__all__"
+
 function formatDate(dateStr: string): string {
 	const [year, month, day] = dateStr.split("-").map(Number)
 	const date = new Date(year!, month! - 1, day)
@@ -29,18 +36,69 @@ function formatDate(dateStr: string): string {
 }
 
 export function MatchPlayResultsTable({ results }: MatchPlayResultsTableProps) {
-	const grouped = React.useMemo(() => {
-		const map = new Map<string, MatchPlayResultRow[]>()
-		for (const result of results) {
-			const group = map.get(result.groupName)
-			if (group) {
-				group.push(result)
-			} else {
-				map.set(result.groupName, [result])
-			}
-		}
-		return map
+	const [currentPage, setCurrentPage] = React.useState(1)
+	const [pageSize, setPageSize] = React.useState<PageSize>(25)
+	const [groupFilter, setGroupFilter] = React.useState<string>(ALL_GROUPS)
+	const [searchTerm, setSearchTerm] = React.useState("")
+
+	const groupNames = React.useMemo(() => {
+		const names = new Set<string>()
+		for (const result of results) names.add(result.groupName)
+		return Array.from(names).sort((a, b) => a.localeCompare(b))
 	}, [results])
+
+	const filteredResults = React.useMemo(() => {
+		const term = searchTerm.trim().toLowerCase()
+		return results.filter((result) => {
+			if (groupFilter !== ALL_GROUPS && result.groupName !== groupFilter) return false
+			if (term) {
+				const home = result.homeClubName.toLowerCase()
+				const away = result.awayClubName.toLowerCase()
+				if (!home.includes(term) && !away.includes(term)) return false
+			}
+			return true
+		})
+	}, [results, groupFilter, searchTerm])
+
+	const sortedResults = React.useMemo(() => {
+		return [...filteredResults].sort((a, b) => {
+			const groupCompare = a.groupName.localeCompare(b.groupName)
+			if (groupCompare !== 0) return groupCompare
+			const dateCompare = a.matchDate.localeCompare(b.matchDate)
+			if (dateCompare !== 0) return dateCompare
+			return a.homeClubName.localeCompare(b.homeClubName)
+		})
+	}, [filteredResults])
+
+	const totalPages = React.useMemo(() => {
+		if (pageSize === "all") return 1
+		return Math.max(1, Math.ceil(sortedResults.length / pageSize))
+	}, [sortedResults.length, pageSize])
+
+	const paginatedResults = React.useMemo(() => {
+		if (pageSize === "all") return sortedResults
+		const startIndex = (currentPage - 1) * pageSize
+		return sortedResults.slice(startIndex, startIndex + pageSize)
+	}, [sortedResults, currentPage, pageSize])
+
+	const handlePageSizeChange = (newSize: PageSize) => {
+		setPageSize(newSize)
+		setCurrentPage(1)
+	}
+
+	const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		setSearchTerm(e.target.value)
+		setCurrentPage(1)
+	}
+
+	const handleGroupChange = (value: string) => {
+		setGroupFilter(value)
+		setCurrentPage(1)
+	}
+
+	const showPagination = pageSize !== "all" && totalPages > 1
+	const showGroupColumn = groupFilter === ALL_GROUPS
+	const isFiltered = groupFilter !== ALL_GROUPS || searchTerm.trim().length > 0
 
 	if (results.length === 0) {
 		return (
@@ -51,95 +109,161 @@ export function MatchPlayResultsTable({ results }: MatchPlayResultsTableProps) {
 	}
 
 	return (
-		<div className="space-y-8">
-			{Array.from(grouped.entries()).map(([groupName, groupResults]) => (
-				<div key={groupName}>
-					<H3 className="mb-3 text-lg">{groupName}</H3>
-					<div className="rounded-lg bg-white shadow-sm">
-						<Table className="min-w-full divide-y divide-gray-200">
-							<TableHeader className="bg-primary-50">
-								<TableRow className="hover:bg-transparent">
-									<TableHead
-										scope="col"
-										className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-primary-900"
-									>
-										Date
-									</TableHead>
-									<TableHead
-										scope="col"
-										className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-primary-900"
-									>
-										Home
-									</TableHead>
-									<TableHead
-										scope="col"
-										className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider text-primary-900"
-									>
-										Score
-									</TableHead>
-									<TableHead
-										scope="col"
-										className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-primary-900"
-									>
-										Away
-									</TableHead>
-									<TableHead
-										scope="col"
-										className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider text-primary-900"
-									>
-										Score
-									</TableHead>
-									<TableHead
-										scope="col"
-										className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider text-primary-900"
-									>
-										Forfeit
-									</TableHead>
-								</TableRow>
-							</TableHeader>
-							<TableBody className="divide-y divide-gray-100 bg-white">
-								{groupResults.map((result) => {
-									const homeScore = parseFloat(result.homeTeamScore)
-									const awayScore = parseFloat(result.awayTeamScore)
-									const homeWins = homeScore > awayScore
-									const awayWins = awayScore > homeScore
-
-									return (
-										<TableRow key={result.id} className="hover:bg-gray-50">
-											<TableCell className="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
-												{formatDate(result.matchDate)}
-											</TableCell>
-											<TableCell
-												className={`whitespace-nowrap px-4 py-3 text-sm ${homeWins ? "font-semibold text-primary-900" : "text-gray-700"}`}
-											>
-												{result.homeClubName}
-											</TableCell>
-											<TableCell
-												className={`whitespace-nowrap px-4 py-3 text-center text-sm ${homeWins ? "font-semibold text-primary-900" : "text-gray-700"}`}
-											>
-												{result.homeTeamScore}
-											</TableCell>
-											<TableCell
-												className={`whitespace-nowrap px-4 py-3 text-sm ${awayWins ? "font-semibold text-primary-900" : "text-gray-700"}`}
-											>
-												{result.awayClubName}
-											</TableCell>
-											<TableCell
-												className={`whitespace-nowrap px-4 py-3 text-center text-sm ${awayWins ? "font-semibold text-primary-900" : "text-gray-700"}`}
-											>
-												{result.awayTeamScore}
-											</TableCell>
-											<TableCell className="whitespace-nowrap px-4 py-3 text-center text-sm">
-												{result.forfeit && <Badge variant="destructive">Forfeit</Badge>}
-											</TableCell>
-										</TableRow>
-									)
-								})}
-							</TableBody>
-						</Table>
-					</div>
+		<div className="space-y-4">
+			{/* Controls row */}
+			<div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+				<div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+					<SearchInput
+						placeholder="Search club..."
+						value={searchTerm}
+						onChange={handleSearchChange}
+					/>
+					<Select value={groupFilter} onValueChange={handleGroupChange}>
+						<SelectTrigger className="h-10 w-full sm:w-48">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value={ALL_GROUPS}>All groups</SelectItem>
+							{groupNames.map((name) => (
+								<SelectItem key={name} value={name}>
+									{name}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
 				</div>
-			))}
+				<div className="flex items-center gap-4">
+					<PageSizeSelect
+						value={String(pageSize)}
+						onChange={(v) =>
+							handlePageSizeChange(v === "all" ? "all" : (Number(v) as 10 | 25 | 50))
+						}
+					/>
+					<p className="text-sm text-gray-600">
+						{sortedResults.length} {sortedResults.length === 1 ? "match" : "matches"}
+						{isFiltered && ` (filtered)`}
+					</p>
+				</div>
+			</div>
+
+			{/* Table */}
+			<div className="rounded-lg bg-white shadow-sm">
+				<Table className="min-w-full divide-y divide-gray-200">
+					<TableHeader className="bg-primary-50">
+						<TableRow className="hover:bg-transparent">
+							{showGroupColumn && (
+								<TableHead
+									scope="col"
+									className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-primary-900"
+								>
+									Group
+								</TableHead>
+							)}
+							<TableHead
+								scope="col"
+								className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-primary-900"
+							>
+								Date
+							</TableHead>
+							<TableHead
+								scope="col"
+								className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-primary-900"
+							>
+								Home
+							</TableHead>
+							<TableHead
+								scope="col"
+								className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider text-primary-900"
+							>
+								Score
+							</TableHead>
+							<TableHead
+								scope="col"
+								className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-primary-900"
+							>
+								Away
+							</TableHead>
+							<TableHead
+								scope="col"
+								className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider text-primary-900"
+							>
+								Score
+							</TableHead>
+							<TableHead
+								scope="col"
+								className="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider text-primary-900"
+							>
+								Forfeit
+							</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody className="divide-y divide-gray-100 bg-white">
+						{paginatedResults.length === 0 ? (
+							<TableRow className="hover:bg-transparent">
+								<TableCell
+									colSpan={showGroupColumn ? 7 : 6}
+									className="px-4 py-8 text-center text-sm text-gray-500"
+								>
+									No matches found
+								</TableCell>
+							</TableRow>
+						) : (
+							paginatedResults.map((result) => {
+								const homeScore = parseFloat(result.homeTeamScore)
+								const awayScore = parseFloat(result.awayTeamScore)
+								const homeWins = homeScore > awayScore
+								const awayWins = awayScore > homeScore
+
+								return (
+									<TableRow key={result.id} className="hover:bg-gray-50">
+										{showGroupColumn && (
+											<TableCell className="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
+												{result.groupName}
+											</TableCell>
+										)}
+										<TableCell className="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
+											{formatDate(result.matchDate)}
+										</TableCell>
+										<TableCell
+											className={`whitespace-nowrap px-4 py-3 text-sm ${homeWins ? "font-semibold text-primary-900" : "text-gray-700"}`}
+										>
+											{result.homeClubName}
+										</TableCell>
+										<TableCell
+											className={`whitespace-nowrap px-4 py-3 text-center text-sm ${homeWins ? "font-semibold text-primary-900" : "text-gray-700"}`}
+										>
+											{result.homeTeamScore}
+										</TableCell>
+										<TableCell
+											className={`whitespace-nowrap px-4 py-3 text-sm ${awayWins ? "font-semibold text-primary-900" : "text-gray-700"}`}
+										>
+											{result.awayClubName}
+										</TableCell>
+										<TableCell
+											className={`whitespace-nowrap px-4 py-3 text-center text-sm ${awayWins ? "font-semibold text-primary-900" : "text-gray-700"}`}
+										>
+											{result.awayTeamScore}
+										</TableCell>
+										<TableCell className="whitespace-nowrap px-4 py-3 text-center text-sm">
+											{result.forfeit && <Badge variant="destructive">Forfeit</Badge>}
+										</TableCell>
+									</TableRow>
+								)
+							})
+						)}
+					</TableBody>
+				</Table>
+			</div>
+
+			{/* Pagination */}
+			{showPagination && (
+				<Pagination
+					currentPage={currentPage}
+					totalPages={totalPages}
+					onPreviousPage={() => setCurrentPage((prev) => prev - 1)}
+					onNextPage={() => setCurrentPage((prev) => prev + 1)}
+				/>
+			)}
 		</div>
 	)
 }


### PR DESCRIPTION
## Summary
- Refactored the public match play results table to a single paginated table with a group-name dropdown, club-name search, and page-size controls. Group column auto-hides when filtered to one group.
- Removed the unused "Enter Results" button (and its Coming Soon dialog) from the match play team group cards.

## Test plan
- [ ] Visit `/match-play/results`: verify search, group dropdown, page-size controls, and match count all work
- [ ] Confirm pagination appears once results exceed the page size
- [ ] Visit `/match-play/teams`: confirm only the "Captains" action remains on team cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)